### PR TITLE
fix: emit per-block layout compound classes in the React and Vue renderers

### DIFF
--- a/packages/visual-editor-renderer-react/src/blocks/core/layout.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/layout.tsx
@@ -11,6 +11,8 @@ import {
     attrString,
     classList,
     formatPercent,
+    layoutClass,
+    layoutPair,
 } from '../../support/attributes';
 import { flexClassNames } from '../../support/flex-serializer';
 import { safeUrl } from '../../support/urlSanitizer';
@@ -26,32 +28,46 @@ export function GroupBlock({ attributes, children }: BlockRendererProps): JSX.El
         ? (tagName as GroupTag)
         : 'div';
 
-    const layout = attrRecord(attributes.layout);
-    const layoutType = attrString(layout.type);
-    const layoutClass =
-        layoutType === 'constrained'
-            ? 'is-layout-constrained'
-            : layoutType === 'flex'
-            ? 'is-layout-flex'
-            : 'is-layout-flow';
-
     const className = attrString(attributes.className);
     const flexClasses = flexClassNames(attributes.artisanpackFlex);
-    const classes = classList(['wp-block-group', layoutClass, ...flexClasses, className]);
+    // #702 — the block-library CSS targets the per-block compound
+    // (`wp-block-group-is-layout-constrained`), so emit it alongside the
+    // shared modifier. `layoutClass()` also covers the `grid` type the
+    // old inline ternary silently rendered as flow.
+    const classes = classList([
+        'wp-block-group',
+        ...layoutPair('group', layoutClass(attributes)),
+        ...flexClasses,
+        className,
+    ]);
 
     return <Tag className={classes}>{children}</Tag>;
 }
 
 export function RowBlock({ attributes, children }: BlockRendererProps): JSX.Element {
     const className = attrString(attributes.className);
-    const classes = classList(['wp-block-group', 'is-layout-flex', 'is-horizontal', className]);
+    // Renders `wp-block-group` markup, so the per-block layout compound
+    // is keyed on `group` rather than `row` (#702).
+    const classes = classList([
+        'wp-block-group',
+        ...layoutPair('group', 'is-layout-flex'),
+        'is-horizontal',
+        className,
+    ]);
 
     return <div className={classes}>{children}</div>;
 }
 
 export function StackBlock({ attributes, children }: BlockRendererProps): JSX.Element {
     const className = attrString(attributes.className);
-    const classes = classList(['wp-block-group', 'is-layout-flex', 'is-vertical', className]);
+    // Renders `wp-block-group` markup, so the per-block layout compound
+    // is keyed on `group` rather than `stack` (#702).
+    const classes = classList([
+        'wp-block-group',
+        ...layoutPair('group', 'is-layout-flex'),
+        'is-vertical',
+        className,
+    ]);
 
     return <div className={classes}>{children}</div>;
 }
@@ -63,8 +79,12 @@ export function ColumnsBlock({ attributes, children }: BlockRendererProps): JSX.
     const verticalAlignment = attrString(attributes.verticalAlignment);
 
     const flexClasses = flexClassNames(attributes.artisanpackFlex);
+    // #702 — columns is a flex layout upstream and its wrapper carries
+    // both the shared modifier and the per-block compound. Neither was
+    // emitted here, so layout rules keyed on either never applied.
     const classes = classList([
         'wp-block-columns',
+        ...layoutPair('columns', 'is-layout-flex'),
         isStacked ? 'is-stacked-on-mobile' : null,
         verticalAlignment !== '' ? `are-vertically-aligned-${verticalAlignment}` : null,
         ...flexClasses,
@@ -119,7 +139,7 @@ export function ButtonsBlock({ attributes, children }: BlockRendererProps): JSX.
 
     const classes = classList([
         'wp-block-buttons',
-        'is-layout-flex',
+        ...layoutPair('buttons', 'is-layout-flex'),
         justify !== '' ? `is-content-justification-${justify}` : 'is-content-justification-left',
         className,
     ]);

--- a/packages/visual-editor-renderer-react/src/blocks/core/postContext.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/postContext.tsx
@@ -11,7 +11,13 @@
  * front-end render structure agree even before a resolver is wired up.
  */
 
-import { attrBoolean, attrInt, attrString, classList } from '../../support/attributes';
+import {
+    attrBoolean,
+    attrInt,
+    attrString,
+    classList,
+    layoutWrapperForBlock,
+} from '../../support/attributes';
 import { safeUrl } from '../../support/urlSanitizer';
 import type { BlockRendererProps } from '../../types';
 
@@ -76,9 +82,15 @@ export function PostContentBlock({ attributes }: BlockRendererProps): JSX.Elemen
     const className = attrString(attributes.className);
     const content = attrString(attributes._resolvedContent);
 
+    // #702 — the block stores a `layout` attribute like every other
+    // layout-supporting block, but the wrapper never surfaced it. Without
+    // `is-layout-constrained` here the content-size containment rules the
+    // theme-token compiler emits for `.wp-block-post-content` can never
+    // match.
     const classes = classList([
         'entry-content',
         'wp-block-post-content',
+        ...layoutWrapperForBlock(attributes, 'post-content'),
         align !== '' ? `has-text-align-${align}` : null,
         className,
     ]);

--- a/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
+++ b/packages/visual-editor-renderer-react/src/blocks/core/query.tsx
@@ -14,7 +14,13 @@
  */
 
 import type { JSX, ReactNode } from 'react';
-import { attrInt, attrString, classList, postTemplateItemSpanClasses } from '../../support/attributes';
+import {
+    attrInt,
+    attrString,
+    classList,
+    layoutPair,
+    postTemplateItemSpanClasses,
+} from '../../support/attributes';
 import type { BlockRendererProps } from '../../types';
 
 interface WrapperProps {
@@ -90,9 +96,14 @@ export function PostTemplateBlock({ attributes, children }: BlockRendererProps):
         // the masonry stylesheet adds `grid-template-rows: masonry` on
         // top via `@supports` for browsers that ship native CSS Grid
         // masonry. The JS bootstrap takes over for the rest.
-        (isGrid || isMasonry) ? 'is-layout-grid' : '',
+        //
+        // #702 — each shared modifier ships with its per-block compound;
+        // the block-library alignment rules key on
+        // `wp-block-post-template-is-layout-flow`. Masonry is an
+        // ArtisanPack extension with no upstream compound, so it stays
+        // unpaired.
+        ...layoutPair('post-template', usesColumns ? 'is-layout-grid' : 'is-layout-flow'),
         isMasonry ? 'is-layout-masonry' : '',
-        !usesColumns ? 'is-layout-flow' : '',
         usesColumns ? `columns-${columns}` : '',
         className,
     ]);

--- a/packages/visual-editor-renderer-react/src/support/attributes.ts
+++ b/packages/visual-editor-renderer-react/src/support/attributes.ts
@@ -95,6 +95,67 @@ export function classList(classes: Array<string | false | null | undefined>): st
         .join(' ');
 }
 
+/**
+ * Layout types the renderers know how to serialize. Anything else stored
+ * on the block falls back to the caller's default so an unknown value
+ * can't mint an arbitrary class token.
+ */
+const SUPPORTED_LAYOUT_TYPES = ['constrained', 'flex', 'flow', 'grid'] as const;
+
+/**
+ * Resolve the shared layout class for a block from its saved
+ * `layout.type` attribute. Mirrors `LayoutSupport::layoutClass()` in the
+ * Blade renderer (#700 / #702).
+ */
+export function layoutClass(attributes: Record<string, unknown>, fallback = 'flow'): string {
+    const supported = SUPPORTED_LAYOUT_TYPES as ReadonlyArray<string>;
+    const type = attrString(attrRecord(attributes.layout).type).trim();
+
+    if (supported.includes(type)) {
+        return `is-layout-${type}`;
+    }
+
+    return `is-layout-${supported.includes(fallback) ? fallback : 'flow'}`;
+}
+
+/**
+ * Pair each shared layout class with its per-block compound so the
+ * block-library CSS that targets `wp-block-{slug}-is-layout-{type}`
+ * matches. Order mirrors upstream: shared class first, compound
+ * immediately after.
+ *
+ * The slug is passed in by each renderer rather than derived from the
+ * block name because several blocks render as a different wrapper than
+ * their name suggests — `artisanpack/row` and `artisanpack/stack` both
+ * render `wp-block-group` markup and therefore need
+ * `wp-block-group-is-layout-flex`, not `wp-block-row-…`.
+ */
+export function layoutPair(blockSlug: string, ...layoutClasses: string[]): string[] {
+    const classes: string[] = [];
+
+    for (const cls of layoutClasses) {
+        if (cls === '') {
+            continue;
+        }
+
+        classes.push(cls, `wp-block-${blockSlug}-${cls}`);
+    }
+
+    return classes;
+}
+
+/**
+ * Shorthand for the common case: resolve the layout class from the
+ * block's attributes and return it paired with its compound.
+ */
+export function layoutWrapperForBlock(
+    attributes: Record<string, unknown>,
+    blockSlug: string,
+    fallback = 'flow'
+): string[] {
+    return layoutPair(blockSlug, layoutClass(attributes, fallback));
+}
+
 export function formatPercent(value: number): string {
     const fixed = value.toFixed(6);
     const trimmed = fixed.replace(/0+$/, '').replace(/\.$/, '');

--- a/packages/visual-editor-renderer-react/src/support/layoutBaselineCss.ts
+++ b/packages/visual-editor-renderer-react/src/support/layoutBaselineCss.ts
@@ -8,6 +8,13 @@
  * blocks-styles.blade.php`. Keep the strings in sync when changing one
  * — the renderer parity tests assert on it.
  *
+ * One deliberate exception (#702): the constrained-group containment
+ * rules at the end have no counterpart in the Blade baseline, because
+ * Blade emits them from `ThemeJsonTokensCompiler::compileLayoutRules()`
+ * gated on `theme.json` layout sizes. This renderer has no equivalent
+ * theme-token compiler, so they live here instead. See the inline note
+ * on those rules for how the gating is preserved.
+ *
  * `:where()` on the flow/constrained selectors keeps specificity at
  * (0,0,0) so any theme rule with higher specificity continues to win —
  * matches WordPress's own output. The `var(--wp--style--block-gap,
@@ -29,4 +36,26 @@ export const LAYOUT_BASELINE_CSS =
     '.is-layout-flex { display: flex; flex-wrap: wrap; align-items: center; }\n' +
     '.is-layout-flex > :is(*, div) { margin: 0; }\n' +
     '.is-layout-grid { display: grid; }\n' +
-    '.is-layout-grid > :is(*, div) { margin: 0; }';
+    '.is-layout-grid > :is(*, div) { margin: 0; }\n' +
+    // #702 — constrained-group containment, mirroring rule set C in the
+    // Blade renderer's `ThemeJsonTokensCompiler::compileLayoutRules()`.
+    // Keyed on the per-block compound rather than the shared modifier so
+    // only wrappers this renderer emits are constrained; host markup that
+    // hand-writes `is-layout-constrained` keeps its own behavior.
+    //
+    // The Blade side gates these on `theme.json` declaring `contentSize`
+    // / `wideSize`; this string is static, so the gating falls out of
+    // `var()` semantics instead — an undefined custom property makes the
+    // declaration invalid at computed-value time, which resolves
+    // `max-width` to its initial `none`.
+    //
+    // The auto margins are NOT gated the same way: with no `contentSize`
+    // configured they still apply, which centers any child that sets its
+    // own width instead of leaving it start-aligned. That matches what
+    // WordPress core emits for a constrained layout, and a constrained
+    // group on a host that declares no content size is a misconfiguration
+    // either way — but it is the one place this baseline goes further
+    // than the Blade renderer's gated output.
+    '.wp-block-group.wp-block-group-is-layout-constrained > :where(:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright)) { max-width: var(--wp--style--global--content-size); margin-left: auto; margin-right: auto; }\n' +
+    '.wp-block-group.wp-block-group-is-layout-constrained > .alignwide { max-width: var(--wp--style--global--wide-size); margin-left: auto; margin-right: auto; }\n' +
+    '.wp-block-group.wp-block-group-is-layout-constrained > .alignfull { max-width: none; }';

--- a/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/BlockTree.test.tsx
@@ -332,20 +332,26 @@ describe('Core layout blocks', () => {
 
         const html = renderTree(tree);
 
-        expect(html).toContain('<div class="wp-block-group is-layout-flow">');
+        expect(html).toContain(
+            '<div class="wp-block-group is-layout-flow wp-block-group-is-layout-flow">'
+        );
         expect(html).toContain('<p class="wp-block-paragraph">Inner</p>');
     });
 
     it('renders a row with is-horizontal class', () => {
         const tree = [makeBlock('core/row', {}, [makeBlock('core/paragraph', { content: 'Row' }, [], 'r1')])];
 
-        expect(renderTree(tree)).toContain('<div class="wp-block-group is-layout-flex is-horizontal">');
+        expect(renderTree(tree)).toContain(
+            '<div class="wp-block-group is-layout-flex wp-block-group-is-layout-flex is-horizontal">'
+        );
     });
 
     it('renders a stack with is-vertical class', () => {
         const tree = [makeBlock('core/stack', {}, [makeBlock('core/paragraph', { content: 'Stacked' }, [], 's1')])];
 
-        expect(renderTree(tree)).toContain('<div class="wp-block-group is-layout-flex is-vertical">');
+        expect(renderTree(tree)).toContain(
+            '<div class="wp-block-group is-layout-flex wp-block-group-is-layout-flex is-vertical">'
+        );
     });
 
     it('renders columns with column widths', () => {

--- a/packages/visual-editor-renderer-react/tests/PostAndSiteContextRendering.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/PostAndSiteContextRendering.test.tsx
@@ -47,7 +47,8 @@ describe('Core post-context blocks', () => {
         const tree = [makeBlock('core/post-content', { _resolvedContent: '<p>Body</p>' })];
 
         expect(renderTree(tree)).toBe(
-            '<div class="entry-content wp-block-post-content"><p>Body</p></div>'
+            '<div class="entry-content wp-block-post-content is-layout-flow wp-block-post-content-is-layout-flow">' +
+                '<p>Body</p></div>'
         );
     });
 

--- a/packages/visual-editor-renderer-react/tests/layoutCompound.test.tsx
+++ b/packages/visual-editor-renderer-react/tests/layoutCompound.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Per-block layout compound classes — React renderer (#702).
+ *
+ * Every layout-supporting wrapper carries the shared `is-layout-{type}`
+ * modifier AND the `wp-block-{slug}-is-layout-{type}` compound the
+ * block-library stylesheet actually targets. The expected strings here
+ * mirror the Blade renderer's partials (fixed in #700) so the three
+ * renderers stay interchangeable.
+ */
+
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import { LAYOUT_BASELINE_CSS } from '../src/support/layoutBaselineCss';
+import { layoutClass, layoutPair } from '../src/support/attributes';
+import { makeBlock, normalizeHtml } from './helpers';
+
+function renderTree(tree: unknown): string {
+    const { container } = render(
+        <BlockTree tree={tree as Parameters<typeof BlockTree>[0]['tree']} />
+    );
+
+    return normalizeHtml(container.innerHTML);
+}
+
+describe('layoutClass()', () => {
+    it('resolves each supported layout type', () => {
+        expect(layoutClass({ layout: { type: 'constrained' } })).toBe('is-layout-constrained');
+        expect(layoutClass({ layout: { type: 'flex' } })).toBe('is-layout-flex');
+        expect(layoutClass({ layout: { type: 'grid' } })).toBe('is-layout-grid');
+        expect(layoutClass({ layout: { type: 'flow' } })).toBe('is-layout-flow');
+    });
+
+    it('falls back rather than minting a class token from an unknown type', () => {
+        expect(layoutClass({ layout: { type: 'evil onerror=x' } })).toBe('is-layout-flow');
+        expect(layoutClass({})).toBe('is-layout-flow');
+        expect(layoutClass({ layout: 'not-an-object' })).toBe('is-layout-flow');
+        expect(layoutClass({}, 'constrained')).toBe('is-layout-constrained');
+        expect(layoutClass({}, 'bogus')).toBe('is-layout-flow');
+    });
+});
+
+describe('layoutPair()', () => {
+    it('emits the shared modifier followed by the per-block compound', () => {
+        expect(layoutPair('group', 'is-layout-flex')).toEqual([
+            'is-layout-flex',
+            'wp-block-group-is-layout-flex',
+        ]);
+    });
+
+    it('skips empty entries', () => {
+        expect(layoutPair('group', '')).toEqual([]);
+    });
+});
+
+describe('layout-supporting wrappers emit the compound class', () => {
+    it('pairs the group layout class', () => {
+        const tree = [makeBlock('core/group', { layout: { type: 'constrained' } }, [])];
+
+        expect(renderTree(tree)).toContain(
+            'class="wp-block-group is-layout-constrained wp-block-group-is-layout-constrained"'
+        );
+    });
+
+    it('renders a grid group as is-layout-grid rather than silently as flow', () => {
+        const tree = [makeBlock('core/group', { layout: { type: 'grid' } }, [])];
+
+        expect(renderTree(tree)).toContain(
+            'class="wp-block-group is-layout-grid wp-block-group-is-layout-grid"'
+        );
+    });
+
+    it('keys row and stack on the group wrapper they actually render', () => {
+        expect(renderTree([makeBlock('core/row', {}, [])])).toContain(
+            'class="wp-block-group is-layout-flex wp-block-group-is-layout-flex is-horizontal"'
+        );
+        expect(renderTree([makeBlock('core/stack', {}, [])])).toContain(
+            'class="wp-block-group is-layout-flex wp-block-group-is-layout-flex is-vertical"'
+        );
+    });
+
+    it('emits the flex layout classes on columns', () => {
+        const tree = [makeBlock('core/columns', {}, [])];
+
+        expect(renderTree(tree)).toContain(
+            'class="wp-block-columns is-layout-flex wp-block-columns-is-layout-flex is-stacked-on-mobile"'
+        );
+    });
+
+    it('pairs the buttons layout class', () => {
+        const tree = [makeBlock('core/buttons', {}, [])];
+
+        expect(renderTree(tree)).toContain(
+            'class="wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex is-content-justification-left"'
+        );
+    });
+
+    it('surfaces the post-content layout attribute', () => {
+        const tree = [
+            makeBlock('core/post-content', {
+                _resolvedContent: '<p>Body</p>',
+                layout: { type: 'constrained' },
+            }),
+        ];
+
+        expect(renderTree(tree)).toContain(
+            'class="entry-content wp-block-post-content is-layout-constrained wp-block-post-content-is-layout-constrained"'
+        );
+    });
+
+    it('defaults post-content to flow when no layout is stored', () => {
+        const tree = [makeBlock('core/post-content', { _resolvedContent: '<p>Body</p>' })];
+
+        expect(renderTree(tree)).toContain(
+            'class="entry-content wp-block-post-content is-layout-flow wp-block-post-content-is-layout-flow"'
+        );
+    });
+
+    it('pairs the post-template layout class and leaves masonry unpaired', () => {
+        expect(renderTree([makeBlock('core/post-template', {}, [])])).toContain(
+            'class="wp-block-post-template is-layout-flow wp-block-post-template-is-layout-flow"'
+        );
+
+        const masonry = renderTree([
+            makeBlock('core/post-template', { layout: 'masonry', columns: 3 }, []),
+        ]);
+
+        expect(masonry).toContain(
+            'wp-block-post-template is-layout-grid wp-block-post-template-is-layout-grid is-layout-masonry columns-3'
+        );
+        expect(masonry).not.toContain('wp-block-post-template-is-layout-masonry');
+    });
+});
+
+describe('LAYOUT_BASELINE_CSS', () => {
+    it('constrains unaligned children of a constrained group', () => {
+        expect(LAYOUT_BASELINE_CSS).toContain(
+            '.wp-block-group.wp-block-group-is-layout-constrained > :where(:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright)) { max-width: var(--wp--style--global--content-size);'
+        );
+        expect(LAYOUT_BASELINE_CSS).toContain(
+            '.wp-block-group.wp-block-group-is-layout-constrained > .alignwide { max-width: var(--wp--style--global--wide-size);'
+        );
+        expect(LAYOUT_BASELINE_CSS).toContain(
+            '.wp-block-group.wp-block-group-is-layout-constrained > .alignfull { max-width: none; }'
+        );
+    });
+});

--- a/packages/visual-editor-renderer-vue/src/blocks/core/layout.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/layout.ts
@@ -12,6 +12,8 @@ import {
     attrString,
     classList,
     formatPercent,
+    layoutClass,
+    layoutPair,
 } from '../../support/attributes';
 import { flexClassNames } from '../../support/flex-serializer';
 import { safeUrl } from '../../support/urlSanitizer';
@@ -31,18 +33,18 @@ export const GroupBlock = defineComponent({
                 ? (tagName as GroupTag)
                 : 'div';
 
-            const layout = attrRecord(props.attributes.layout);
-            const layoutType = attrString(layout.type);
-            const layoutClass =
-                layoutType === 'constrained'
-                    ? 'is-layout-constrained'
-                    : layoutType === 'flex'
-                    ? 'is-layout-flex'
-                    : 'is-layout-flow';
-
             const className = attrString(props.attributes.className);
             const flexClasses = flexClassNames(props.attributes.artisanpackFlex);
-            const classes = classList(['wp-block-group', layoutClass, ...flexClasses, className]);
+            // #702 — the block-library CSS targets the per-block compound
+            // (`wp-block-group-is-layout-constrained`), so emit it alongside
+            // the shared modifier. `layoutClass()` also covers the `grid`
+            // type the old inline ternary silently rendered as flow.
+            const classes = classList([
+                'wp-block-group',
+                ...layoutPair('group', layoutClass(props.attributes)),
+                ...flexClasses,
+                className,
+            ]);
 
             return h(tag, { class: classes }, slots.default ? slots.default() : []);
         };
@@ -55,7 +57,14 @@ export const RowBlock = defineComponent({
     setup(props, { slots }) {
         return () => {
             const className = attrString(props.attributes.className);
-            const classes = classList(['wp-block-group', 'is-layout-flex', 'is-horizontal', className]);
+            // Renders `wp-block-group` markup, so the per-block layout
+            // compound is keyed on `group` rather than `row` (#702).
+            const classes = classList([
+                'wp-block-group',
+                ...layoutPair('group', 'is-layout-flex'),
+                'is-horizontal',
+                className,
+            ]);
 
             return h('div', { class: classes }, slots.default ? slots.default() : []);
         };
@@ -68,7 +77,14 @@ export const StackBlock = defineComponent({
     setup(props, { slots }) {
         return () => {
             const className = attrString(props.attributes.className);
-            const classes = classList(['wp-block-group', 'is-layout-flex', 'is-vertical', className]);
+            // Renders `wp-block-group` markup, so the per-block layout
+            // compound is keyed on `group` rather than `stack` (#702).
+            const classes = classList([
+                'wp-block-group',
+                ...layoutPair('group', 'is-layout-flex'),
+                'is-vertical',
+                className,
+            ]);
 
             return h('div', { class: classes }, slots.default ? slots.default() : []);
         };
@@ -88,8 +104,13 @@ export const ColumnsBlock = defineComponent({
             const verticalAlignment = attrString(props.attributes.verticalAlignment);
 
             const flexClasses = flexClassNames(props.attributes.artisanpackFlex);
+            // #702 — columns is a flex layout upstream and its wrapper
+            // carries both the shared modifier and the per-block compound.
+            // Neither was emitted here, so layout rules keyed on either
+            // never applied.
             const classes = classList([
                 'wp-block-columns',
+                ...layoutPair('columns', 'is-layout-flex'),
                 isStacked ? 'is-stacked-on-mobile' : null,
                 verticalAlignment !== '' ? `are-vertically-aligned-${verticalAlignment}` : null,
                 ...flexClasses,
@@ -161,7 +182,7 @@ export const ButtonsBlock = defineComponent({
 
             const classes = classList([
                 'wp-block-buttons',
-                'is-layout-flex',
+                ...layoutPair('buttons', 'is-layout-flex'),
                 justify !== '' ? `is-content-justification-${justify}` : 'is-content-justification-left',
                 className,
             ]);

--- a/packages/visual-editor-renderer-vue/src/blocks/core/postContext.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/postContext.ts
@@ -9,7 +9,13 @@
 
 import { defineComponent, h } from 'vue';
 import type { VNode } from 'vue';
-import { attrBoolean, attrInt, attrString, classList } from '../../support/attributes';
+import {
+    attrBoolean,
+    attrInt,
+    attrString,
+    classList,
+    layoutWrapperForBlock,
+} from '../../support/attributes';
 import { safeUrl } from '../../support/urlSanitizer';
 import { blockRendererProps } from '../shared';
 
@@ -80,9 +86,15 @@ export const PostContentBlock = defineComponent({
             const className = attrString(props.attributes.className);
             const content = attrString(props.attributes._resolvedContent);
 
+            // #702 — the block stores a `layout` attribute like every other
+            // layout-supporting block, but the wrapper never surfaced it.
+            // Without `is-layout-constrained` here the content-size
+            // containment rules the theme-token compiler emits for
+            // `.wp-block-post-content` can never match.
             const classes = classList([
                 'entry-content',
                 'wp-block-post-content',
+                ...layoutWrapperForBlock(props.attributes, 'post-content'),
                 align !== '' ? `has-text-align-${align}` : null,
                 className,
             ]);

--- a/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
+++ b/packages/visual-editor-renderer-vue/src/blocks/core/query.ts
@@ -13,7 +13,13 @@
  */
 
 import { defineComponent, h } from 'vue';
-import { attrInt, attrString, classList, postTemplateItemSpanClasses } from '../../support/attributes';
+import {
+    attrInt,
+    attrString,
+    classList,
+    layoutPair,
+    postTemplateItemSpanClasses,
+} from '../../support/attributes';
 import { blockRendererProps } from '../shared';
 
 /**
@@ -93,9 +99,14 @@ export const PostTemplateBlock = defineComponent({
                     // stylesheet adds `grid-template-rows: masonry` on
                     // top via `@supports` for browsers that ship native
                     // CSS Grid masonry. The JS bootstrap packs the rest.
-                    (isGrid || isMasonry) ? 'is-layout-grid' : '',
+                    //
+                    // #702 — each shared modifier ships with its per-block
+                    // compound; the block-library alignment rules key on
+                    // `wp-block-post-template-is-layout-flow`. Masonry is
+                    // an ArtisanPack extension with no upstream compound,
+                    // so it stays unpaired.
+                    ...layoutPair('post-template', usesColumns ? 'is-layout-grid' : 'is-layout-flow'),
                     isMasonry ? 'is-layout-masonry' : '',
-                    !usesColumns ? 'is-layout-flow' : '',
                     usesColumns ? `columns-${columns}` : '',
                     className,
                 ]),

--- a/packages/visual-editor-renderer-vue/src/support/attributes.ts
+++ b/packages/visual-editor-renderer-vue/src/support/attributes.ts
@@ -95,6 +95,67 @@ export function classList(classes: Array<string | false | null | undefined>): st
         .join(' ');
 }
 
+/**
+ * Layout types the renderers know how to serialize. Anything else stored
+ * on the block falls back to the caller's default so an unknown value
+ * can't mint an arbitrary class token.
+ */
+const SUPPORTED_LAYOUT_TYPES = ['constrained', 'flex', 'flow', 'grid'] as const;
+
+/**
+ * Resolve the shared layout class for a block from its saved
+ * `layout.type` attribute. Mirrors `LayoutSupport::layoutClass()` in the
+ * Blade renderer (#700 / #702).
+ */
+export function layoutClass(attributes: Record<string, unknown>, fallback = 'flow'): string {
+    const supported = SUPPORTED_LAYOUT_TYPES as ReadonlyArray<string>;
+    const type = attrString(attrRecord(attributes.layout).type).trim();
+
+    if (supported.includes(type)) {
+        return `is-layout-${type}`;
+    }
+
+    return `is-layout-${supported.includes(fallback) ? fallback : 'flow'}`;
+}
+
+/**
+ * Pair each shared layout class with its per-block compound so the
+ * block-library CSS that targets `wp-block-{slug}-is-layout-{type}`
+ * matches. Order mirrors upstream: shared class first, compound
+ * immediately after.
+ *
+ * The slug is passed in by each renderer rather than derived from the
+ * block name because several blocks render as a different wrapper than
+ * their name suggests — `artisanpack/row` and `artisanpack/stack` both
+ * render `wp-block-group` markup and therefore need
+ * `wp-block-group-is-layout-flex`, not `wp-block-row-…`.
+ */
+export function layoutPair(blockSlug: string, ...layoutClasses: string[]): string[] {
+    const classes: string[] = [];
+
+    for (const cls of layoutClasses) {
+        if (cls === '') {
+            continue;
+        }
+
+        classes.push(cls, `wp-block-${blockSlug}-${cls}`);
+    }
+
+    return classes;
+}
+
+/**
+ * Shorthand for the common case: resolve the layout class from the
+ * block's attributes and return it paired with its compound.
+ */
+export function layoutWrapperForBlock(
+    attributes: Record<string, unknown>,
+    blockSlug: string,
+    fallback = 'flow'
+): string[] {
+    return layoutPair(blockSlug, layoutClass(attributes, fallback));
+}
+
 export function formatPercent(value: number): string {
     const fixed = value.toFixed(6);
     const trimmed = fixed.replace(/0+$/, '').replace(/\.$/, '');

--- a/packages/visual-editor-renderer-vue/src/support/layoutBaselineCss.ts
+++ b/packages/visual-editor-renderer-vue/src/support/layoutBaselineCss.ts
@@ -8,6 +8,13 @@
  * blocks-styles.blade.php`. Keep the strings in sync when changing one
  * — the renderer parity tests assert on it.
  *
+ * One deliberate exception (#702): the constrained-group containment
+ * rules at the end have no counterpart in the Blade baseline, because
+ * Blade emits them from `ThemeJsonTokensCompiler::compileLayoutRules()`
+ * gated on `theme.json` layout sizes. This renderer has no equivalent
+ * theme-token compiler, so they live here instead. See the inline note
+ * on those rules for how the gating is preserved.
+ *
  * `:where()` on the flow/constrained selectors keeps specificity at
  * (0,0,0) so any theme rule with higher specificity continues to win —
  * matches WordPress's own output. The `var(--wp--style--block-gap,
@@ -29,4 +36,26 @@ export const LAYOUT_BASELINE_CSS =
     '.is-layout-flex { display: flex; flex-wrap: wrap; align-items: center; }\n' +
     '.is-layout-flex > :is(*, div) { margin: 0; }\n' +
     '.is-layout-grid { display: grid; }\n' +
-    '.is-layout-grid > :is(*, div) { margin: 0; }';
+    '.is-layout-grid > :is(*, div) { margin: 0; }\n' +
+    // #702 — constrained-group containment, mirroring rule set C in the
+    // Blade renderer's `ThemeJsonTokensCompiler::compileLayoutRules()`.
+    // Keyed on the per-block compound rather than the shared modifier so
+    // only wrappers this renderer emits are constrained; host markup that
+    // hand-writes `is-layout-constrained` keeps its own behavior.
+    //
+    // The Blade side gates these on `theme.json` declaring `contentSize`
+    // / `wideSize`; this string is static, so the gating falls out of
+    // `var()` semantics instead — an undefined custom property makes the
+    // declaration invalid at computed-value time, which resolves
+    // `max-width` to its initial `none`.
+    //
+    // The auto margins are NOT gated the same way: with no `contentSize`
+    // configured they still apply, which centers any child that sets its
+    // own width instead of leaving it start-aligned. That matches what
+    // WordPress core emits for a constrained layout, and a constrained
+    // group on a host that declares no content size is a misconfiguration
+    // either way — but it is the one place this baseline goes further
+    // than the Blade renderer's gated output.
+    '.wp-block-group.wp-block-group-is-layout-constrained > :where(:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright)) { max-width: var(--wp--style--global--content-size); margin-left: auto; margin-right: auto; }\n' +
+    '.wp-block-group.wp-block-group-is-layout-constrained > .alignwide { max-width: var(--wp--style--global--wide-size); margin-left: auto; margin-right: auto; }\n' +
+    '.wp-block-group.wp-block-group-is-layout-constrained > .alignfull { max-width: none; }';

--- a/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/BlockTree.test.ts
@@ -335,20 +335,26 @@ describe('Core layout blocks', () => {
 
         const html = renderTree(tree);
 
-        expect(html).toContain('<div class="wp-block-group is-layout-flow">');
+        expect(html).toContain(
+            '<div class="wp-block-group is-layout-flow wp-block-group-is-layout-flow">'
+        );
         expect(html).toContain('<p class="wp-block-paragraph">Inner</p>');
     });
 
     it('renders a row with is-horizontal class', () => {
         const tree = [makeBlock('core/row', {}, [makeBlock('core/paragraph', { content: 'Row' }, [], 'r1')])];
 
-        expect(renderTree(tree)).toContain('<div class="wp-block-group is-layout-flex is-horizontal">');
+        expect(renderTree(tree)).toContain(
+            '<div class="wp-block-group is-layout-flex wp-block-group-is-layout-flex is-horizontal">'
+        );
     });
 
     it('renders a stack with is-vertical class', () => {
         const tree = [makeBlock('core/stack', {}, [makeBlock('core/paragraph', { content: 'Stacked' }, [], 's1')])];
 
-        expect(renderTree(tree)).toContain('<div class="wp-block-group is-layout-flex is-vertical">');
+        expect(renderTree(tree)).toContain(
+            '<div class="wp-block-group is-layout-flex wp-block-group-is-layout-flex is-vertical">'
+        );
     });
 
     it('renders columns with column widths', () => {

--- a/packages/visual-editor-renderer-vue/tests/PostAndSiteContextRendering.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/PostAndSiteContextRendering.test.ts
@@ -48,7 +48,8 @@ describe('Core post-context blocks (Vue)', () => {
         const tree = [makeBlock('core/post-content', { _resolvedContent: '<p>Body</p>' })];
 
         expect(renderTree(tree)).toBe(
-            '<div class="entry-content wp-block-post-content"><p>Body</p></div>'
+            '<div class="entry-content wp-block-post-content is-layout-flow wp-block-post-content-is-layout-flow">' +
+                '<p>Body</p></div>'
         );
     });
 

--- a/packages/visual-editor-renderer-vue/tests/layoutCompound.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/layoutCompound.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Per-block layout compound classes — Vue renderer (#702).
+ *
+ * Every layout-supporting wrapper carries the shared `is-layout-{type}`
+ * modifier AND the `wp-block-{slug}-is-layout-{type}` compound the
+ * block-library stylesheet actually targets. The expected strings here
+ * mirror the Blade renderer's partials (fixed in #700) so the three
+ * renderers stay interchangeable.
+ */
+
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+import '../src/index';
+import { BlockTree } from '../src/BlockTree';
+import { LAYOUT_BASELINE_CSS } from '../src/support/layoutBaselineCss';
+import { layoutClass, layoutPair } from '../src/support/attributes';
+import { makeBlock, normalizeHtml } from './helpers';
+import type { Block } from '../src/types';
+
+function renderTree(tree: unknown): string {
+    const wrapper = mount(BlockTree, {
+        props: {
+            tree: tree as Block[] | string | null | undefined,
+        },
+    });
+
+    return normalizeHtml(wrapper.html());
+}
+
+describe('layoutClass()', () => {
+    it('resolves each supported layout type', () => {
+        expect(layoutClass({ layout: { type: 'constrained' } })).toBe('is-layout-constrained');
+        expect(layoutClass({ layout: { type: 'flex' } })).toBe('is-layout-flex');
+        expect(layoutClass({ layout: { type: 'grid' } })).toBe('is-layout-grid');
+        expect(layoutClass({ layout: { type: 'flow' } })).toBe('is-layout-flow');
+    });
+
+    it('falls back rather than minting a class token from an unknown type', () => {
+        expect(layoutClass({ layout: { type: 'evil onerror=x' } })).toBe('is-layout-flow');
+        expect(layoutClass({})).toBe('is-layout-flow');
+        expect(layoutClass({ layout: 'not-an-object' })).toBe('is-layout-flow');
+        expect(layoutClass({}, 'constrained')).toBe('is-layout-constrained');
+        expect(layoutClass({}, 'bogus')).toBe('is-layout-flow');
+    });
+});
+
+describe('layoutPair()', () => {
+    it('emits the shared modifier followed by the per-block compound', () => {
+        expect(layoutPair('group', 'is-layout-flex')).toEqual([
+            'is-layout-flex',
+            'wp-block-group-is-layout-flex',
+        ]);
+    });
+
+    it('skips empty entries', () => {
+        expect(layoutPair('group', '')).toEqual([]);
+    });
+});
+
+describe('layout-supporting wrappers emit the compound class', () => {
+    it('pairs the group layout class', () => {
+        const tree = [makeBlock('core/group', { layout: { type: 'constrained' } }, [])];
+
+        expect(renderTree(tree)).toContain(
+            'class="wp-block-group is-layout-constrained wp-block-group-is-layout-constrained"'
+        );
+    });
+
+    it('renders a grid group as is-layout-grid rather than silently as flow', () => {
+        const tree = [makeBlock('core/group', { layout: { type: 'grid' } }, [])];
+
+        expect(renderTree(tree)).toContain(
+            'class="wp-block-group is-layout-grid wp-block-group-is-layout-grid"'
+        );
+    });
+
+    it('keys row and stack on the group wrapper they actually render', () => {
+        expect(renderTree([makeBlock('core/row', {}, [])])).toContain(
+            'class="wp-block-group is-layout-flex wp-block-group-is-layout-flex is-horizontal"'
+        );
+        expect(renderTree([makeBlock('core/stack', {}, [])])).toContain(
+            'class="wp-block-group is-layout-flex wp-block-group-is-layout-flex is-vertical"'
+        );
+    });
+
+    it('emits the flex layout classes on columns', () => {
+        const tree = [makeBlock('core/columns', {}, [])];
+
+        expect(renderTree(tree)).toContain(
+            'class="wp-block-columns is-layout-flex wp-block-columns-is-layout-flex is-stacked-on-mobile"'
+        );
+    });
+
+    it('pairs the buttons layout class', () => {
+        const tree = [makeBlock('core/buttons', {}, [])];
+
+        expect(renderTree(tree)).toContain(
+            'class="wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex is-content-justification-left"'
+        );
+    });
+
+    it('surfaces the post-content layout attribute', () => {
+        const tree = [
+            makeBlock('core/post-content', {
+                _resolvedContent: '<p>Body</p>',
+                layout: { type: 'constrained' },
+            }),
+        ];
+
+        expect(renderTree(tree)).toContain(
+            'class="entry-content wp-block-post-content is-layout-constrained wp-block-post-content-is-layout-constrained"'
+        );
+    });
+
+    it('defaults post-content to flow when no layout is stored', () => {
+        const tree = [makeBlock('core/post-content', { _resolvedContent: '<p>Body</p>' })];
+
+        expect(renderTree(tree)).toContain(
+            'class="entry-content wp-block-post-content is-layout-flow wp-block-post-content-is-layout-flow"'
+        );
+    });
+
+    it('pairs the post-template layout class and leaves masonry unpaired', () => {
+        expect(renderTree([makeBlock('core/post-template', {}, [])])).toContain(
+            'class="wp-block-post-template is-layout-flow wp-block-post-template-is-layout-flow"'
+        );
+
+        const masonry = renderTree([
+            makeBlock('core/post-template', { layout: 'masonry', columns: 3 }, []),
+        ]);
+
+        expect(masonry).toContain(
+            'wp-block-post-template is-layout-grid wp-block-post-template-is-layout-grid is-layout-masonry columns-3'
+        );
+        expect(masonry).not.toContain('wp-block-post-template-is-layout-masonry');
+    });
+});
+
+describe('LAYOUT_BASELINE_CSS', () => {
+    it('constrains unaligned children of a constrained group', () => {
+        expect(LAYOUT_BASELINE_CSS).toContain(
+            '.wp-block-group.wp-block-group-is-layout-constrained > :where(:not(.alignwide):not(.alignfull):not(.alignleft):not(.alignright)) { max-width: var(--wp--style--global--content-size);'
+        );
+        expect(LAYOUT_BASELINE_CSS).toContain(
+            '.wp-block-group.wp-block-group-is-layout-constrained > .alignwide { max-width: var(--wp--style--global--wide-size);'
+        );
+        expect(LAYOUT_BASELINE_CSS).toContain(
+            '.wp-block-group.wp-block-group-is-layout-constrained > .alignfull { max-width: none; }'
+        );
+    });
+});

--- a/packages/visual-editor-renderer-vue/tests/parity.test.ts
+++ b/packages/visual-editor-renderer-vue/tests/parity.test.ts
@@ -215,6 +215,32 @@ const FIXTURES: Array<{ name: string; tree: Block[] }> = [
         ],
     },
     {
+        // #702 — the constrained / grid layout branches and the
+        // post-content layout attribute all mint per-block compound
+        // classes, so they get their own parity fixture.
+        name: 'group layout variants + post-content layout',
+        tree: [
+            makeBlock(
+                'core/group',
+                { layout: { type: 'constrained' } },
+                [makeBlock('core/paragraph', { content: 'Constrained' }, [], 'cp')],
+                'gc'
+            ),
+            makeBlock(
+                'core/group',
+                { layout: { type: 'grid' } },
+                [makeBlock('core/paragraph', { content: 'Grid' }, [], 'gp')],
+                'gg'
+            ),
+            makeBlock(
+                'core/post-content',
+                { _resolvedContent: '<p>Body</p>', layout: { type: 'constrained' } },
+                [],
+                'pc'
+            ),
+        ],
+    },
+    {
         name: 'row / stack containers',
         tree: [
             makeBlock(


### PR DESCRIPTION
## Description

#700 fixed the missing `wp-block-{slug}-is-layout-{type}` compound class in the Blade renderer only, so the React and Vue renderers kept emitting the pre-fix markup and began rendering differently from Blade for the same block tree. This ports #700's approach to both JS renderers.

**Closes:** #702

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #702 (follow-up to #700 / PR #701)

## Motivation and Context

The three renderers are meant to be interchangeable — `parity.test.ts` describes them as sharing "the Blade partial contract" — but that test only compares React against Vue, never against Blade. That is why #700 was safe to land Blade-only, and also why the resulting divergence went unnoticed: a page rendered through React or Vue was no longer visually identical to the same tree rendered through Blade.

The block-library stylesheet targets the per-block compound exclusively for several rules (constrained containment on `.wp-block-group`, alignment handling on `.wp-block-post-template`), so emitting only the shared `is-layout-*` modifier left those rules unmatched.

## Changes Made

- Added `layoutClass()` / `layoutPair()` / `layoutWrapperForBlock()` to `src/support/attributes.ts` in both packages — the JS twin of `LayoutSupport.php`. `layoutClass()` resolves `layout.type` against a `constrained|flex|flow|grid` allowlist so an unknown stored value cannot mint an arbitrary class token. The slug is passed in explicitly rather than derived from the block name, because `row` and `stack` both render `wp-block-group` markup and need the `group` compound.
- `group`, `row`, `stack`, `buttons` and `post-template` now pair each shared modifier with its per-block compound.
- `columns` emits `is-layout-flex` + compound, where it previously emitted no layout class at all.
- `post-content` now reads its `layout` attribute, defaulting to `flow` (matching `group` and upstream).
- `group` gained the `grid` branch its ternary chain silently rendered as `is-layout-flow` — a pre-existing divergence, not fallout from #700.
- `is-layout-masonry` deliberately stays unpaired: it is an ArtisanPack extension with no upstream compound.
- `LAYOUT_BASELINE_CSS` gained the constrained-group containment rules mirroring rule set C in `ThemeJsonTokensCompiler::compileLayoutRules()`.

Both packages change together because `parity.test.ts` asserts React and Vue produce byte-identical HTML — patching one alone fails the suite.

### Note on the baseline CSS gating

The Blade side gates those containment rules on `theme.json` declaring `contentSize` / `wideSize`, but `LAYOUT_BASELINE_CSS` is a static string with no theme-token compiler behind it. The gating instead falls out of `var()` semantics: an undefined custom property makes the declaration invalid at computed-value time, so `max-width` resolves to its initial `none`.

The auto margins are *not* gated the same way — with no `contentSize` configured they still apply, which centers any child that sets its own width. That matches what WordPress core emits for a constrained layout, and it is documented inline as the one place this baseline goes further than the Blade renderer's gated output.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- Browser (if applicable): n/a — renderer output asserted at the markup level
- PHP Version: 8.4.3
- Project Version: `release/1.6`

**Tests Performed:**
1. `npm test` — 331 files / 3077 tests passing (was 3042; +35 new).
2. `./vendor/bin/pest` — 1700 passing, 1 skipped, 4493 assertions. The Blade renderer is untouched by this change and stays green.
3. `npx tsc --noEmit` — 0 errors in either renderer package. (Pre-existing errors elsewhere under `resources/js/` are unrelated and untouched.)
4. `npm run verify:parity` — all 152 blocks registered across react / vue / blade.
5. Manual verification in the dev app: rendered a constrained group through the React and Vue renderers and confirmed the wrapper class and the child containment now match the Blade output for the same tree.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:**

Not applicable — this change adds CSS class tokens to existing wrapper elements and adds layout rules to a stylesheet. No interactive elements, focus order, semantics, ARIA, or color values are introduced or altered. The one perceivable effect is that constrained groups now cap their unaligned children at the theme's content size, which is the intended (and upstream-standard) reading-width behavior.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- New `tests/layoutCompound.test.tsx` (React) and `tests/layoutCompound.test.ts` (Vue) — 13 tests each. Cover every layout-supporting wrapper's exact class string, the `grid` branch, `post-content` with and without a stored layout, `post-template` grid/flow/masonry, the `LAYOUT_BASELINE_CSS` containment rules, and the helper's allowlist fallback (including that a hostile `layout.type` cannot mint a class token).
- New parity fixture in `parity.test.ts` covering the constrained and grid group branches plus a layout-carrying `post-content`, so React/Vue drift on the new paths is caught.
- Updated the existing class-string assertions in `BlockTree.test.*` and `PostAndSiteContextRendering.test.*` to the new expected markup.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:**

Docblocks on the three new helpers explaining the allowlist and why the slug is passed in explicitly rather than derived from the block name. Inline notes at each call site. The `layoutBaselineCss.ts` header previously said to keep the string byte-identical with the Blade partial; it now records the deliberate exception and why it exists.

## Screenshots

n/a — the change is at the class-attribute level; the expected markup is asserted exactly in the new test suites.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Follow-up worth considering

The issue notes that nothing currently guards against the three renderers drifting on *markup*: `scripts/verify-renderer-parity.mjs` only checks that each renderer registers the same block *names*, and `parity.test.ts` only compares React against Vue. A Blade-vs-JS markup fixture check would have caught this class of bug at the point #700 landed. Not done here to keep the fix scoped — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved layout class generation for groups, rows, stacks, columns, buttons, post content, and post templates.
  * Added consistent layout-specific classes across React and Vue renderers.
  * Improved handling of constrained layouts, including content-width, wide-width, and full-width children.
  * Added safe fallback behavior for unsupported layout types.

* **Tests**
  * Expanded coverage for layout rendering, wrapper classes, masonry layouts, constrained groups, and React/Vue parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->