### PR TITLE
fix: serve renderer-blade front-end assets without a publish step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **Blade renderer front-end assets no longer 404 on a fresh install** (#699) —
+  every stylesheet `<x-ve-blocks-styles />` links under
+  `/vendor/visual-editor-renderer-blade/` returned Laravel's 404 page until the
+  consumer discovered and ran
+  `vendor:publish --tag=visual-editor-renderer-blade-assets`, leaving the front
+  end with no block-gap between paragraphs, no content-size containment on
+  constrained groups, and `core/columns` collapsed to a vertical stack.
+  `visual-editor-renderer-blade` now registers a route that serves the bundled
+  block-library and `frontend/*` assets straight from the package, so the
+  styles resolve with no install step and package upgrades take effect
+  immediately. Publishing still works and still wins — the web server serves
+  the static file before the route is reached — but it is now an optional
+  performance choice rather than a silent requirement.
 - **Per-block layout classes in the Blade renderer** (#700) — layout-supporting
   partials emitted only the shared `is-layout-{type}` modifier, so the shipped
   block-library rules that key on the per-block compound

--- a/packages/visual-editor-renderer-blade/README.md
+++ b/packages/visual-editor-renderer-blade/README.md
@@ -58,15 +58,22 @@ It emits:
    `var(--wp--preset--color--primary)` resolve against the active theme's
    palette.
 
-Publish the bundled CSS into your `public/` directory first:
+No install step is required. The package registers a route that serves the
+bundled CSS and `frontend/*` assets from
+`/vendor/visual-editor-renderer-blade/` — the prefix `<x-ve-blocks-styles />`
+points to by default — so package upgrades take effect immediately.
+
+If you would rather your web server serve the files statically, publish them
+into `public/`:
 
 ```sh
 php artisan vendor:publish --tag=visual-editor-renderer-blade-assets
 ```
 
-That drops `style.css` and `theme.css` at
-`public/vendor/visual-editor-renderer-blade/`, which `<x-ve-blocks-styles />`
-points to by default.
+That drops `style.css`, `theme.css`, and the `frontend/` assets at
+`public/vendor/visual-editor-renderer-blade/`. Those static files win over the
+package route at the same URLs, so re-run the command with `--force` after
+every package upgrade to pick up refreshed CSS.
 
 ### Props
 

--- a/packages/visual-editor-renderer-blade/routes/assets.php
+++ b/packages/visual-editor-renderer-blade/routes/assets.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Front-end asset delivery route for the Blade renderer package.
+ *
+ * `<x-ve-blocks-styles />` links to `/vendor/visual-editor-renderer-blade/…`
+ * for the bundled block-library CSS and the per-block `frontend/*` styles
+ * and scripts. Historically those files only existed after the consumer ran
+ * `vendor:publish --tag=visual-editor-renderer-blade-assets`, so a fresh
+ * install served Laravel's 404 page for every stylesheet and the front end
+ * rendered unstyled (#699).
+ *
+ * This route streams the files straight out of the package so the assets
+ * work with no publish step, and package upgrades take effect immediately.
+ * When a consumer *has* published the assets, the web server serves the
+ * static file from `public/` and this route is never reached — publishing
+ * remains a valid (and slightly faster) opt-in.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.6.0
+ */
+
+declare( strict_types=1 );
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+Route::get( 'vendor/visual-editor-renderer-blade/{path}', function ( Request $request, string $path ) {
+	$root = realpath( __DIR__ . '/../resources/assets' );
+
+	abort_if( false === $root, 404 );
+
+	// Extensions are allow-listed rather than inferred so the route can
+	// never be coaxed into serving PHP or another executable payload out
+	// of the package directory.
+	$contentTypes = [
+		'css' => 'text/css',
+		'js'  => 'text/javascript',
+	];
+
+	$extension = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+
+	abort_unless( isset( $contentTypes[ $extension ] ), 404 );
+
+	// Mirrors the publish mapping: `frontend/*` comes from the frontend
+	// directory, everything else from the block-library bundle, both of
+	// which flatten into the same public URL prefix.
+	$relative = str_starts_with( $path, 'frontend/' )
+		? $path
+		: 'block-library/' . $path;
+
+	$file = realpath( $root . '/' . $relative );
+
+	// `realpath()` resolves `..` segments and symlinks, so the prefix check
+	// below rejects anything that escapes the bundled assets directory.
+	abort_if( false === $file || ! is_file( $file ), 404 );
+	abort_unless( str_starts_with( $file, $root . DIRECTORY_SEPARATOR ), 404 );
+
+	// The URLs are not fingerprinted, so a long max-age would pin browsers
+	// to the pre-upgrade CSS. Revalidation keeps upgrades instant while the
+	// ETag / Last-Modified pair below still short-circuits to a 304.
+	$response = response()->file( $file, [
+		'Content-Type'           => $contentTypes[ $extension ],
+		'Cache-Control'          => 'public, max-age=0, must-revalidate',
+		'X-Content-Type-Options' => 'nosniff',
+	] );
+
+	$response->setAutoLastModified();
+	$response->setAutoEtag();
+	$response->isNotModified( $request );
+
+	return $response;
+} )
+	// Restricted to the characters a bundled asset path can actually contain.
+	// Containment is enforced by the `realpath()` check in the closure — this
+	// pattern is the outer guard that keeps null bytes and control characters
+	// from ever reaching `realpath()`, which throws a ValueError (a 500) on
+	// them rather than returning false.
+	->where( 'path', '[A-Za-z0-9._\-\/]+' )
+	->name( 'visual-editor-renderer-blade.asset' );

--- a/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
+++ b/packages/visual-editor-renderer-blade/src/View/Components/BlocksStylesComponent.php
@@ -8,10 +8,14 @@
  *
  *   1. `<link>`s to the bundled `@wordpress/block-library` `style.css`
  *      + `theme.css` — the same CSS the editor uses, copied into this
- *      package's `resources/assets/block-library/` directory. The
- *      `vendor:publish --tag=visual-editor-renderer-blade-assets`
- *      command copies those files into `public/vendor/visual-editor-
- *      renderer-blade/`, where this component points by default.
+ *      package's `resources/assets/block-library/` directory. The package
+ *      registers a route that serves those files from
+ *      `/vendor/visual-editor-renderer-blade/`, where this component
+ *      points by default, so no install step is required. Hosts that
+ *      prefer static delivery can still run
+ *      `vendor:publish --tag=visual-editor-renderer-blade-assets` to copy
+ *      the files into `public/`; the web server then serves them and the
+ *      route is never reached.
  *   2. A `<style>` block with `--wp--preset--*` CSS custom properties
  *      compiled from a `theme.json` payload, so a block referencing e.g.
  *      `var(--wp--preset--color--primary)` resolves on the public site
@@ -46,10 +50,10 @@ use Illuminate\View\Component;
 class BlocksStylesComponent extends Component
 {
 	/**
-	 * URL the bundled block-library CSS is served from. The
-	 * `vendor:publish --tag=visual-editor-renderer-blade-assets` step
-	 * copies the files to `public/vendor/visual-editor-renderer-blade/`,
-	 * which the asset() helper resolves to this URL.
+	 * URL the bundled block-library CSS is served from. The package's
+	 * asset route answers this prefix out of the box; publishing to
+	 * `public/vendor/visual-editor-renderer-blade/` shadows it with a
+	 * static file at the same URL.
 	 */
 	public const DEFAULT_ASSET_BASE = '/vendor/visual-editor-renderer-blade';
 

--- a/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
+++ b/packages/visual-editor-renderer-blade/src/VisualEditorRendererBladeServiceProvider.php
@@ -210,6 +210,12 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 	{
 		$this->loadViewsFrom( __DIR__ . '/../resources/views', 'visual-editor-renderer-blade' );
 
+		// #699 — serves the bundled block-library + `frontend/*` assets from
+		// the package so `<x-ve-blocks-styles />` resolves with no publish
+		// step. A consumer that has published the assets never reaches this
+		// route: the web server hands back the static `public/` file first.
+		$this->loadRoutesFrom( __DIR__ . '/../routes/assets.php' );
+
 		Blade::component( BlocksComponent::class, 've-blocks' );
 		Blade::component( BlocksStylesComponent::class, 've-blocks-styles' );
 		Blade::component( TemplateComponent::class, 've-template' );
@@ -219,11 +225,18 @@ class VisualEditorRendererBladeServiceProvider extends ServiceProvider
 				__DIR__ . '/../resources/views' => resource_path( 'views/vendor/visual-editor-renderer-blade' ),
 			], 'visual-editor-blade-views' );
 
-			// Asset publish path: copies the bundled `@wordpress/block-library`
-			// CSS to the consumer's `public/vendor/visual-editor-renderer-blade/`,
-			// which `<x-ve-blocks-styles />` links to by default. Also ships the
+			// Optional asset publish path: copies the bundled
+			// `@wordpress/block-library` CSS to the consumer's
+			// `public/vendor/visual-editor-renderer-blade/`, which
+			// `<x-ve-blocks-styles />` links to by default. Also ships the
 			// accordion + tabs front-end stylesheets and interactivity script
 			// under `public/vendor/visual-editor-renderer-blade/frontend/`.
+			//
+			// Publishing is no longer required — the route registered above
+			// serves the same files straight out of the package (#699). It
+			// stays available for hosts that prefer the web server to serve
+			// the assets statically; those hosts must re-run the command with
+			// `--force` after every package upgrade to pick up refreshed CSS.
 			$this->publishes( [
 				__DIR__ . '/../resources/assets/block-library' => public_path( 'vendor/visual-editor-renderer-blade' ),
 				__DIR__ . '/../resources/assets/frontend'      => public_path( 'vendor/visual-editor-renderer-blade/frontend' ),

--- a/packages/visual-editor-renderer-blade/tests/Feature/AssetRouteTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/AssetRouteTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Covers the package asset route added for #699 — the bundled block-library
+ * and `frontend/*` files must resolve with no `vendor:publish` step.
+ *
+ * Content types are asserted with `toStartWith()` rather than
+ * `assertHeader()` because Laravel appends a charset to text responses.
+ */
+
+declare( strict_types=1 );
+
+it( 'serves the bundled block-library stylesheet', function () {
+	$response = $this->get( '/vendor/visual-editor-renderer-blade/style.css' );
+
+	$response->assertOk();
+
+	expect( (string) $response->headers->get( 'Content-Type' ) )->toStartWith( 'text/css' );
+	expect( $response->streamedContent() )->toContain( '.wp-block-columns' );
+} );
+
+it( 'serves the bundled theme stylesheet', function () {
+	$response = $this->get( '/vendor/visual-editor-renderer-blade/theme.css' );
+
+	$response->assertOk();
+
+	expect( (string) $response->headers->get( 'Content-Type' ) )->toStartWith( 'text/css' );
+} );
+
+it( 'serves the frontend stylesheets linked by the styles component', function ( string $file ) {
+	$response = $this->get( '/vendor/visual-editor-renderer-blade/frontend/' . $file );
+
+	$response->assertOk();
+
+	expect( (string) $response->headers->get( 'Content-Type' ) )->toStartWith( 'text/css' );
+} )->with( [
+	'accordion.css',
+	'tabs.css',
+	'grid.css',
+	'marquee.css',
+	'breadcrumbs.css',
+	'query-pagination.css',
+	'flex-layout.css',
+	'photo-grid.css',
+	'post-template.css',
+	'post-variant.css',
+	'masonry.css',
+	'social-icons.css',
+] );
+
+it( 'serves the frontend scripts with a javascript content type', function ( string $file ) {
+	$response = $this->get( '/vendor/visual-editor-renderer-blade/frontend/' . $file );
+
+	$response->assertOk();
+
+	expect( (string) $response->headers->get( 'Content-Type' ) )->toStartWith( 'text/javascript' );
+} )->with( [
+	'interactivity.js',
+	'masonry-fallback.js',
+] );
+
+it( 'marks served assets nosniff so a mistyped response cannot be re-interpreted', function () {
+	$this->get( '/vendor/visual-editor-renderer-blade/style.css' )
+		->assertOk()
+		->assertHeader( 'X-Content-Type-Options', 'nosniff' );
+} );
+
+it( 'revalidates rather than pinning browsers to pre-upgrade CSS', function () {
+	$response = $this->get( '/vendor/visual-editor-renderer-blade/style.css' );
+
+	$response->assertOk();
+
+	expect( (string) $response->headers->get( 'Cache-Control' ) )
+		->toContain( 'must-revalidate' )
+		->not->toContain( 'immutable' );
+
+	expect( $response->headers->get( 'ETag' ) )->not->toBeNull();
+} );
+
+it( 'answers a matching If-None-Match with a 304', function () {
+	$etag = $this->get( '/vendor/visual-editor-renderer-blade/style.css' )
+		->headers->get( 'ETag' );
+
+	expect( $etag )->not->toBeNull();
+
+	$this->withHeaders( [ 'If-None-Match' => $etag ] )
+		->get( '/vendor/visual-editor-renderer-blade/style.css' )
+		->assertStatus( 304 );
+} );
+
+it( '404s for a missing asset', function () {
+	$this->get( '/vendor/visual-editor-renderer-blade/does-not-exist.css' )
+		->assertNotFound();
+} );
+
+it( '404s for a non-allow-listed extension inside the assets directory', function ( string $path ) {
+	$this->get( '/vendor/visual-editor-renderer-blade/' . $path )
+		->assertNotFound();
+} )->with( [
+	'README.md',
+	'style',
+	'style.css.php',
+] );
+
+it( 'refuses to traverse outside the bundled assets directory', function ( string $path ) {
+	$this->get( '/vendor/visual-editor-renderer-blade/' . $path )
+		->assertNotFound();
+} )->with( [
+	'../composer.json',
+	'../../composer.json',
+	'../../src/BlockRenderer.php',
+	'frontend/../../../composer.json',
+	'block-library/../../../composer.json',
+] );
+
+/**
+ * A null byte reaching `realpath()` raises a ValueError — a 500 rather than
+ * a 404. The route's `where()` pattern rejects the request before then.
+ * CR / LF / TAB never get this far: Symfony's `Request` rejects those URIs
+ * outright with a 400.
+ */
+it( '404s on a null byte instead of surfacing a realpath ValueError', function ( string $path ) {
+	$this->get( '/vendor/visual-editor-renderer-blade/' . $path )
+		->assertNotFound();
+} )->with( [
+	'null byte mid-path'   => "frontend/x\0/style.css",
+	'null byte before ext' => "style\0.css",
+] );


### PR DESCRIPTION
## Description

Installing the package into a consumer app left every front-end stylesheet 404ing. The bundled CSS on disk was already correct — only the *delivery* was broken. Nothing copied the files into the consumer's `public/` directory unless they discovered `vendor:publish --tag=visual-editor-renderer-blade-assets` on their own, and every upgrade then required `--force` to re-copy refreshed CSS.

`visual-editor-renderer-blade` now registers a route that streams the bundled block-library and `frontend/*` assets straight out of the package. The styles resolve with no install step and package upgrades take effect immediately.

Publishing still works and still wins: when the files exist in `public/`, the web server serves the static file and the route is never reached. It becomes an optional performance choice rather than a silent requirement.

**Closes:** #699

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #699

## Motivation and Context

A fresh install rendered a visibly broken front end with no indication why — paragraphs collapsed together with no block-gap, `is-layout-constrained` groups ran edge-to-edge instead of capping to `contentSize`, and `core/columns` stacked vertically because it never picked up `display: flex`. The only signal was a set of silent 404s in the Network tab, each returning Laravel's ~6.5 KB HTML error page in place of a stylesheet.

## Changes Made

- **New `routes/assets.php`** — serves `/vendor/visual-editor-renderer-blade/{path}` from the package's `resources/assets/`, mirroring the publish mapping (`frontend/*` → `assets/frontend/`, everything else → `assets/block-library/`).
- **Provider** loads the route file in `boot()`; the publish tag is retained and re-documented as optional.
- **Security controls on the route**, since it serves files off disk at an unauthenticated path:
  - extension allow-list (`css`, `js`) so it can never be coaxed into serving a PHP or other executable payload;
  - `realpath()` containment check against the assets root, which resolves `..` segments *and* symlinks before the prefix comparison, rejecting traversal and symlink escapes alike;
  - route pattern restricting the path charset, keeping null bytes away from `realpath()` (which raises a `ValueError`, i.e. a 500, rather than returning `false`);
  - `X-Content-Type-Options: nosniff` on every response.
- **Cache headers** are `public, max-age=0, must-revalidate` plus ETag/Last-Modified. Deliberately *not* `immutable` — the URLs are not fingerprinted, so a long max-age would pin browsers to pre-upgrade CSS and reintroduce the stale-asset half of this bug. Repeat requests still short-circuit to a 304.
- Docblocks, package README, and CHANGELOG updated to describe the new default.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- Browser: Chrome (DevTools Network panel)
- PHP Version: 8.4
- Project Version: visual-editor 1.6 branch, verified against a consumer app on visual-editor 1.5.5 / cms-framework 2.7.2

**Tests Performed:**

1. Full package suite: **1730 passed, 1 skipped** (4546 assertions).
2. End-to-end in the consumer app from the issue (`~/Herd/artisanpack-ui`), with the previously-published `public/vendor/visual-editor-renderer-blade/` removed to reproduce a fresh install:
   - all **16** asset URLs `<x-ve-blocks-styles />` emits in that app return 200 with correct content types (`style.css` = 159 KB, previously a 404 page);
   - confirmed the theme templates pass no `asset-base` override, so those 16 URLs are the ones actually in play;
   - repeat request returns **304**;
   - restoring the published copy confirmed nginx serves it statically and the route is bypassed — publishing remains fully backward-compatible.
3. Verified the route survives `php artisan route:cache` (Laravel 11+ serializes closure routes; `__DIR__` still resolves correctly) and continues to serve and to block traversal while cached.
4. Attack battery against the live app using `curl --path-as-is`, so dot segments are not collapsed client-side before reaching the server — plain, single- and double-encoded traversal, null bytes, and non-allow-listed extensions all return 4xx with no file disclosure.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — this change is asset delivery only and adds no markup or interactive surface. It is, if anything, accessibility-positive in effect: it restores the stylesheets that give the front end its intended layout and spacing.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** New `tests/Feature/AssetRouteTest.php`, 31 cases covering every stylesheet and script the styles component links, content types, `nosniff`, cache/304 revalidation, 404s for missing files and non-allow-listed extensions (`README.md`, extensionless, `style.css.php`), five path-traversal attempts, and null-byte handling.

## Documentation

- [x] Inline code documentation added
- [x] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** New route file carries a full file-level docblock explaining the delivery model. Package README's asset section rewritten — publishing is now presented as the optional static-delivery path, including the `--force`-on-upgrade caveat that applies to it. Provider and `BlocksStylesComponent` docblocks updated. CHANGELOG entry added under Unreleased → Fixed.

## Screenshots

Not included — the fix is verified above by HTTP status, content type, and payload size rather than by appearance.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [ ] Code has been linted (no lint tooling in this package; style matched to surrounding files by hand)
- [ ] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated
