### PR TITLE
fix: paint the post-editor canvas from theme.json colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **Post-editor canvas now honours the theme's `theme.json` colors** (#695) —
+  the canvas body is painted through two package-owned custom properties
+  (`--ap-editor-canvas-bg` / `--ap-editor-canvas-fg`) that nothing ever
+  assigned, so both fell back to their light-mode defaults. Because the rule
+  that reads them is an element+class compound (`body.editor-styles-wrapper`,
+  specificity 0,1,1) it out-specifies a theme's bare `.editor-styles-wrapper`
+  rule regardless of source order, so no theme sheet could correct it: a dark
+  theme rendered a white canvas with dark body text. The canvas now derives
+  both properties from the resolved theme.json's `styles.color` and injects
+  them as a `:root` rule. The same defect applied one level down —
+  `DEFAULT_CANVAS_STYLES` hardcoded `#111827` for `h1`..`h6` at the same
+  specificity, which on a dark ground rendered headings near-invisible — so
+  the heading baseline now chains through a matching
+  `--ap-editor-canvas-heading-fg`, sourced from `styles.elements.heading` (or
+  `h1`..`h6` when every declared level agrees) and falling back to the canvas
+  foreground. Themes declaring no colors keep the previous light defaults, and
+  a host rule on `body` / `.editor-styles-wrapper` still overrides the theme.
+  The site-editor canvas is unaffected.
 - **Blade renderer front-end assets no longer 404 on a fresh install** (#699) —
   every stylesheet `<x-ve-blocks-styles />` links under
   `/vendor/visual-editor-renderer-blade/` returned Laravel's 404 page until the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `h1`..`h6` when every declared level agrees) and falling back to the canvas
   foreground. Themes declaring no colors keep the previous light defaults, and
   a host rule on `body` / `.editor-styles-wrapper` still overrides the theme.
-  The site-editor canvas is unaffected.
+  A theme that declares a background without a paired text color gets a legible
+  foreground derived for it via the package's WCAG helpers rather than half a
+  pair, and WordPress's `var:preset|color|slug` shorthand is accepted alongside
+  the `var(--wp--preset--color--slug)` CSS form. The site-editor canvas is
+  unaffected.
 - **Blade renderer front-end assets no longer 404 on a fresh install** (#699) —
   every stylesheet `<x-ve-blocks-styles />` links under
   `/vendor/visual-editor-renderer-blade/` returned Laravel's 404 page until the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   A theme that declares a background without a paired text color gets a legible
   foreground derived for it via the package's WCAG helpers rather than half a
   pair, and WordPress's `var:preset|color|slug` shorthand is accepted alongside
-  the `var(--wp--preset--color--slug)` CSS form. The site-editor canvas is
-  unaffected.
+  the `var(--wp--preset--color--slug)` CSS form. That derivation covers every
+  opaque CSS color syntax a `theme.json` may carry — `rgb()`, `hsl()`, named
+  colors, and alpha-bearing hex — not just the plain hex the WCAG helpers parse
+  natively, so an unpaired dark background written as `rgb(17 24 39)` or `black`
+  is no longer emitted with an unreadable foreground left on the default. Values
+  with no fixed opaque color (`var()` references, translucent colors) are left
+  alone rather than guessed at, and the theme's own syntax is what reaches the
+  stylesheet — normalisation is used only to measure contrast. The site-editor
+  canvas is unaffected.
 - **Blade renderer front-end assets no longer 404 on a fresh install** (#699) —
   every stylesheet `<x-ve-blocks-styles />` links under
   `/vendor/visual-editor-renderer-blade/` returned Laravel's 404 page until the

--- a/resources/js/visual-editor/editor-settings.ts
+++ b/resources/js/visual-editor/editor-settings.ts
@@ -130,7 +130,16 @@ export const DEFAULT_CANVAS_STYLES = `
     font-weight: 700;
     line-height: 1.2;
     margin: 1.4em 0 0.6em;
-    color: #111827;
+    /*
+     * #695 — this baseline (0,1,1) out-specifies a theme's bare
+     * \`h1\`..\`h6\` rules, so a hardcoded hex here pins headings to a
+     * light-mode color no dark theme can shift: on a dark canvas they
+     * render near-invisible against the ground. Chain through the
+     * canvas tokens instead — the theme's heading color when it
+     * declares one, otherwise the canvas foreground, otherwise the
+     * original light default. See \`editor/canvas-color-tokens.ts\`.
+     */
+    color: var(--ap-editor-canvas-heading-fg, var(--ap-editor-canvas-fg, #111827));
 }
 
 .editor-styles-wrapper h1 { font-size: 2.5rem; }

--- a/resources/js/visual-editor/editor/__tests__/canvas-color-tokens.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/canvas-color-tokens.test.ts
@@ -62,12 +62,33 @@ describe('buildCanvasColorTokenCss', () => {
         expect(buildCanvasColorTokenCss({ color: ['#000'] })).toBeNull();
     });
 
-    it('emits only the half the theme declares', () => {
-        const bgOnly = buildCanvasColorTokenCss({
-            color: { background: '#111827' },
+    it('accepts WordPress preset shorthand as well as the CSS form', () => {
+        // theme.json may carry either; the handbook recommends the
+        // shorthand, and `/global-styles/base` returns the manifest
+        // verbatim, so both shapes reach this module.
+        const css = buildCanvasColorTokenCss({
+            color: {
+                background: 'var:preset|color|base',
+                text: 'var:custom|contrast|primary',
+            },
         });
 
-        expect(bgOnly).toContain('--ap-editor-canvas-bg: #111827;');
+        expect(css).toContain(
+            '--ap-editor-canvas-bg: var(--wp--preset--color--base);'
+        );
+        expect(css).toContain(
+            '--ap-editor-canvas-fg: var(--wp--custom--contrast--primary);'
+        );
+    });
+
+    it('emits only the half the theme declares', () => {
+        // A light background keeps the default foreground legible, so
+        // nothing is synthesized and the variable stays unset.
+        const bgOnly = buildCanvasColorTokenCss({
+            color: { background: '#fafafa' },
+        });
+
+        expect(bgOnly).toContain('--ap-editor-canvas-bg: #fafafa;');
         expect(bgOnly).not.toContain('--ap-editor-canvas-fg');
 
         const fgOnly = buildCanvasColorTokenCss({
@@ -76,6 +97,59 @@ describe('buildCanvasColorTokenCss', () => {
 
         expect(fgOnly).toContain('--ap-editor-canvas-fg: #ffffff;');
         expect(fgOnly).not.toContain('--ap-editor-canvas-bg');
+    });
+
+    /*
+     * A dark background with no paired text color would leave body text
+     * on the `#1f2937` default and headings on `#111827` — the exact
+     * invisible-on-dark failure this change exists to remove. The pair
+     * gets completed rather than half-emitted.
+     */
+    describe('unpaired background', () => {
+        it('synthesizes a legible foreground for a dark background', () => {
+            const css = buildCanvasColorTokenCss({
+                color: { background: '#111827' },
+            });
+
+            expect(css).toContain('--ap-editor-canvas-bg: #111827;');
+            expect(css).toContain('--ap-editor-canvas-fg: #ffffff;');
+        });
+
+        it('leaves headings to inherit the synthesized foreground', () => {
+            // No heading token means the baseline chains
+            // `heading-fg` → `fg`, so headings follow the same legible
+            // color rather than the light `#111827` default.
+            const css = buildCanvasColorTokenCss({
+                color: { background: '#111827' },
+            });
+
+            expect(css).not.toContain('--ap-editor-canvas-heading-fg');
+        });
+
+        it('never overrides a text color the theme declared', () => {
+            // An explicit low-contrast pairing is the theme's decision;
+            // the canvas should render what the front end renders.
+            const css = buildCanvasColorTokenCss({
+                color: { background: '#111827', text: '#1f2937' },
+            });
+
+            expect(css).toContain('--ap-editor-canvas-fg: #1f2937;');
+            expect(css).not.toContain('#ffffff');
+        });
+
+        it('does not guess for a background it cannot measure', () => {
+            // A `var()` reference resolves only in the browser. Themes
+            // using presets have a resolved palette and declare `text`
+            // alongside `background` in practice.
+            const css = buildCanvasColorTokenCss({
+                color: { background: 'var(--wp--preset--color--base)' },
+            });
+
+            expect(css).toContain(
+                '--ap-editor-canvas-bg: var(--wp--preset--color--base);'
+            );
+            expect(css).not.toContain('--ap-editor-canvas-fg');
+        });
     });
 
     it('admits the CSS color shapes a theme.json legitimately uses', () => {

--- a/resources/js/visual-editor/editor/__tests__/canvas-color-tokens.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/canvas-color-tokens.test.ts
@@ -1,0 +1,229 @@
+/**
+ * `canvas-color-tokens.ts` derives the two custom properties the canvas
+ * body is painted with (`--ap-editor-canvas-bg` / `--ap-editor-canvas-fg`)
+ * from the resolved theme.json's `styles.color` (#695).
+ *
+ * The regression these cover: nothing supplied those variables, so a
+ * dark theme rendered a white canvas with white (invisible) headings.
+ * The important half of the contract is the *absence* case — a theme
+ * with no `styles.color` must leave the variables unset so the hex
+ * fallbacks in `canvas-theme-tokens.css` still apply.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    buildCanvasColorTokenCss,
+    canvasColorTokenStyle,
+} from '../canvas-color-tokens';
+
+describe('buildCanvasColorTokenCss', () => {
+    it('emits both variables for a dark theme', () => {
+        const css = buildCanvasColorTokenCss({
+            color: { background: '#111827', text: '#FFFFFF' },
+        });
+
+        expect(css).toContain(':root {');
+        expect(css).toContain('--ap-editor-canvas-bg: #111827;');
+        expect(css).toContain('--ap-editor-canvas-fg: #FFFFFF;');
+    });
+
+    it('passes `var()` preset references through verbatim', () => {
+        // theme.json commonly stores preset references rather than
+        // literals; the emitter defines those presets on `:root` inside
+        // the same document, so they resolve as-is.
+        const css = buildCanvasColorTokenCss({
+            color: {
+                background: 'var(--wp--preset--color--base)',
+                text: 'var(--wp--preset--color--text)',
+            },
+        });
+
+        expect(css).toContain(
+            '--ap-editor-canvas-bg: var(--wp--preset--color--base);'
+        );
+        expect(css).toContain(
+            '--ap-editor-canvas-fg: var(--wp--preset--color--text);'
+        );
+    });
+
+    it('leaves the variables unset when the theme declares no styles.color', () => {
+        expect(buildCanvasColorTokenCss(undefined)).toBeNull();
+        expect(buildCanvasColorTokenCss({})).toBeNull();
+        expect(buildCanvasColorTokenCss({ color: {} })).toBeNull();
+        expect(
+            buildCanvasColorTokenCss({ typography: { fontSize: '16px' } })
+        ).toBeNull();
+    });
+
+    it('ignores a non-object styles.color node', () => {
+        expect(buildCanvasColorTokenCss({ color: null })).toBeNull();
+        expect(buildCanvasColorTokenCss({ color: 'dark' })).toBeNull();
+        expect(buildCanvasColorTokenCss({ color: ['#000'] })).toBeNull();
+    });
+
+    it('emits only the half the theme declares', () => {
+        const bgOnly = buildCanvasColorTokenCss({
+            color: { background: '#111827' },
+        });
+
+        expect(bgOnly).toContain('--ap-editor-canvas-bg: #111827;');
+        expect(bgOnly).not.toContain('--ap-editor-canvas-fg');
+
+        const fgOnly = buildCanvasColorTokenCss({
+            color: { text: '#ffffff' },
+        });
+
+        expect(fgOnly).toContain('--ap-editor-canvas-fg: #ffffff;');
+        expect(fgOnly).not.toContain('--ap-editor-canvas-bg');
+    });
+
+    it('admits the CSS color shapes a theme.json legitimately uses', () => {
+        for (const value of [
+            '#111827',
+            '#fff',
+            'rebeccapurple',
+            'var(--wp--preset--color--base)',
+            'rgb(0 0 0 / 50%)',
+            'color-mix(in srgb, #111827 50%, white)',
+        ]) {
+            expect(
+                buildCanvasColorTokenCss({ color: { background: value } })
+            ).toContain(`--ap-editor-canvas-bg: ${value};`);
+        }
+    });
+
+    it('drops values that would swallow the rest of the rule', () => {
+        // Both of these slip past a naive `[{};<>]` denylist and take the
+        // whole `:root` entry down with them — an unterminated comment
+        // and an unbalanced paren each consume to end-of-stylesheet.
+        // Dropping just the value keeps the `var()` fallbacks in play.
+        for (const value of ['#111 /*', 'var(--wp--preset--color--base', '#fff )']) {
+            expect(
+                buildCanvasColorTokenCss({
+                    color: { background: value, text: '#000' },
+                })
+            ).not.toContain('--ap-editor-canvas-bg');
+        }
+
+        // ...and the surviving half is still emitted.
+        expect(
+            buildCanvasColorTokenCss({
+                color: { background: '#111 /*', text: '#000' },
+            })
+        ).toContain('--ap-editor-canvas-fg: #000;');
+    });
+
+    it('drops empty, non-string, and unsafe values rather than emitting them', () => {
+        expect(
+            buildCanvasColorTokenCss({ color: { background: '   ', text: 42 } })
+        ).toBeNull();
+
+        // A value that could close the declaration block is dropped, not
+        // sanitized — theme.json colors never legitimately contain these.
+        const css = buildCanvasColorTokenCss({
+            color: { background: '#fff; } body { display: none;', text: '#000' },
+        });
+
+        expect(css).not.toContain('display: none');
+        expect(css).not.toContain('--ap-editor-canvas-bg');
+        expect(css).toContain('--ap-editor-canvas-fg: #000;');
+    });
+
+    it('trims surrounding whitespace off a declared value', () => {
+        expect(
+            buildCanvasColorTokenCss({ color: { background: '  #111827  ' } })
+        ).toContain('--ap-editor-canvas-bg: #111827;');
+    });
+});
+
+/*
+ * #695, second half — `DEFAULT_CANVAS_STYLES` pins headings to a
+ * hardcoded `#111827` at a specificity a theme's bare `h1`..`h6` rules
+ * can't beat, so on a dark canvas headings render against a ground of
+ * nearly the same color. The baseline now chains through
+ * `--ap-editor-canvas-heading-fg` → `--ap-editor-canvas-fg` → the
+ * original light default; these cover which of those the theme picks.
+ */
+describe('buildCanvasColorTokenCss — heading color', () => {
+    it('prefers the `heading` element group', () => {
+        const css = buildCanvasColorTokenCss({
+            color: { text: '#FFFFFF' },
+            elements: { heading: { color: { text: '#E5E7EB' } } },
+        });
+
+        expect(css).toContain('--ap-editor-canvas-heading-fg: #E5E7EB;');
+    });
+
+    it('falls back to h1..h6 when every declared level agrees', () => {
+        const css = buildCanvasColorTokenCss({
+            elements: {
+                h1: { color: { text: '#E5E7EB' } },
+                h2: { color: { text: '#E5E7EB' } },
+            },
+        });
+
+        expect(css).toContain('--ap-editor-canvas-heading-fg: #E5E7EB;');
+    });
+
+    it('leaves the token unset when per-level colors diverge', () => {
+        // One variable can't express six colors; leaving it unset makes
+        // headings inherit the canvas foreground rather than pick a
+        // level's color arbitrarily.
+        const css = buildCanvasColorTokenCss({
+            color: { text: '#FFFFFF' },
+            elements: {
+                h1: { color: { text: '#E5E7EB' } },
+                h2: { color: { text: '#9CA3AF' } },
+            },
+        });
+
+        expect(css).toContain('--ap-editor-canvas-fg: #FFFFFF;');
+        expect(css).not.toContain('--ap-editor-canvas-heading-fg');
+    });
+
+    it('leaves the token unset for a theme that styles headings without color', () => {
+        // The real-world case: `elements.h1..h6` carry typography only,
+        // so headings must inherit the canvas foreground.
+        const css = buildCanvasColorTokenCss({
+            color: { background: '#111827', text: '#FFFFFF' },
+            elements: {
+                h1: { typography: { fontWeight: '600' } },
+                h2: { typography: { fontWeight: '600' } },
+            },
+        });
+
+        expect(css).toContain('--ap-editor-canvas-fg: #FFFFFF;');
+        expect(css).not.toContain('--ap-editor-canvas-heading-fg');
+    });
+
+    it('emits heading colors even when the theme declares no canvas colors', () => {
+        const css = buildCanvasColorTokenCss({
+            elements: { heading: { color: { text: '#E5E7EB' } } },
+        });
+
+        expect(css).toContain('--ap-editor-canvas-heading-fg: #E5E7EB;');
+        expect(css).not.toContain('--ap-editor-canvas-bg');
+    });
+
+    it('ignores malformed element nodes', () => {
+        expect(
+            buildCanvasColorTokenCss({ elements: { heading: 'white', h1: null } })
+        ).toBeNull();
+        expect(buildCanvasColorTokenCss({ elements: [] })).toBeNull();
+    });
+});
+
+describe('canvasColorTokenStyle', () => {
+    it('wraps the rule in the BlockCanvas style-entry shape', () => {
+        expect(
+            canvasColorTokenStyle({ color: { background: '#111827' } })
+        ).toEqual({
+            css: expect.stringContaining('--ap-editor-canvas-bg: #111827;'),
+        });
+    });
+
+    it('is null when there is nothing to emit, so no entry is appended', () => {
+        expect(canvasColorTokenStyle({})).toBeNull();
+    });
+});

--- a/resources/js/visual-editor/editor/__tests__/canvas-color-tokens.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/canvas-color-tokens.test.ts
@@ -150,6 +150,60 @@ describe('buildCanvasColorTokenCss', () => {
             );
             expect(css).not.toContain('--ap-editor-canvas-fg');
         });
+
+        /*
+         * The contrast helpers are hex-only, but every one of these
+         * syntaxes passes `ALLOWED_VALUE` and gets emitted. Without
+         * normalisation the derivation silently no-ops and the canvas
+         * keeps its `#1f2937` default on a near-black ground — #695
+         * all over again, just reached via a different value syntax.
+         */
+        it.each([
+            ['rgb()', 'rgb(17 24 39)'],
+            ['legacy rgb()', 'rgb(17, 24, 39)'],
+            ['opaque rgba()', 'rgba(17, 24, 39, 1)'],
+            ['hsl()', 'hsl(220 39% 11%)'],
+            ['a named color', 'black'],
+            ['opaque 8-digit hex', '#111827ff'],
+        ])('derives a foreground for a dark background in %s', (_label, value) => {
+            const css = buildCanvasColorTokenCss({ color: { background: value } });
+
+            expect(css).toContain(`--ap-editor-canvas-bg: ${value};`);
+            expect(css).toContain('--ap-editor-canvas-fg: #ffffff;');
+        });
+
+        it('leaves a light non-hex background on the legible default', () => {
+            // Derivation is not blanket normalisation — it only fires
+            // when the default would actually be unreadable.
+            const css = buildCanvasColorTokenCss({
+                color: { background: 'rgb(250 250 250)' },
+            });
+
+            expect(css).toContain('--ap-editor-canvas-bg: rgb(250 250 250);');
+            expect(css).not.toContain('--ap-editor-canvas-fg');
+        });
+
+        it('emits the background verbatim rather than the normalised hex', () => {
+            // Normalisation exists to measure contrast; the theme's own
+            // syntax is what reaches the stylesheet.
+            const css = buildCanvasColorTokenCss({
+                color: { background: 'hsl(220 39% 11%)' },
+            });
+
+            expect(css).toContain('--ap-editor-canvas-bg: hsl(220 39% 11%);');
+            expect(css).not.toContain('#111827;');
+        });
+
+        it('does not guess for a translucent background', () => {
+            // What a translucent color renders as depends on whatever is
+            // painted behind it, so there is nothing to measure.
+            const css = buildCanvasColorTokenCss({
+                color: { background: 'rgba(17, 24, 39, 0.5)' },
+            });
+
+            expect(css).toContain('--ap-editor-canvas-bg: rgba(17, 24, 39, 0.5);');
+            expect(css).not.toContain('--ap-editor-canvas-fg');
+        });
     });
 
     it('admits the CSS color shapes a theme.json legitimately uses', () => {

--- a/resources/js/visual-editor/editor/__tests__/css-color-parse.test.ts
+++ b/resources/js/visual-editor/editor/__tests__/css-color-parse.test.ts
@@ -1,0 +1,129 @@
+/**
+ * `css-color-parse.ts` normalises the opaque CSS color syntaxes a
+ * theme.json may carry into the `#rrggbb` form the WCAG helpers can
+ * measure (#695).
+ *
+ * The regression these guard: `canvas-color-tokens.ts` accepts every CSS
+ * color syntax but the contrast math is hex-only, so a dark
+ * `rgb()` / `hsl()` / named background with no paired text color emitted
+ * the background while leaving the foreground on the light default —
+ * the same invisible-text failure #695 exists to remove, reached through
+ * a different value syntax.
+ *
+ * The other half of the contract is the `null` cases: a value with no
+ * fixed opaque color must not be guessed at.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { toMeasurableHex } from '../css-color-parse';
+
+describe('toMeasurableHex', () => {
+    it('passes hex through, expanding the shorthand form', () => {
+        expect(toMeasurableHex('#111827')).toBe('#111827');
+        expect(toMeasurableHex('#FFF')).toBe('#ffffff');
+        expect(toMeasurableHex('#1a2b3c')).toBe('#1a2b3c');
+    });
+
+    it('resolves alpha-bearing hex only when fully opaque', () => {
+        expect(toMeasurableHex('#111827ff')).toBe('#111827');
+        expect(toMeasurableHex('#111f')).toBe('#111111');
+
+        // Translucent renders against an unknown backdrop.
+        expect(toMeasurableHex('#11182780')).toBeNull();
+        expect(toMeasurableHex('#1118')).toBeNull();
+    });
+
+    it('rejects hex of a length CSS does not define', () => {
+        expect(toMeasurableHex('#12')).toBeNull();
+        expect(toMeasurableHex('#12345')).toBeNull();
+        expect(toMeasurableHex('#1234567')).toBeNull();
+        expect(toMeasurableHex('#zzzzzz')).toBeNull();
+    });
+
+    it('resolves named colors case-insensitively', () => {
+        expect(toMeasurableHex('black')).toBe('#000000');
+        expect(toMeasurableHex('White')).toBe('#ffffff');
+        expect(toMeasurableHex('REBECCAPURPLE')).toBe('#663399');
+        expect(toMeasurableHex('midnightblue')).toBe('#191970');
+
+        // Both spellings of the grey family are defined.
+        expect(toMeasurableHex('gray')).toBe('#808080');
+        expect(toMeasurableHex('grey')).toBe('#808080');
+    });
+
+    it('treats `transparent` and keywords as unmeasurable', () => {
+        expect(toMeasurableHex('transparent')).toBeNull();
+        expect(toMeasurableHex('currentColor')).toBeNull();
+        expect(toMeasurableHex('inherit')).toBeNull();
+    });
+
+    it('resolves rgb() in both the legacy and modern syntaxes', () => {
+        expect(toMeasurableHex('rgb(17, 24, 39)')).toBe('#111827');
+        expect(toMeasurableHex('rgb(17 24 39)')).toBe('#111827');
+        expect(toMeasurableHex('rgba(17, 24, 39, 1)')).toBe('#111827');
+        expect(toMeasurableHex('rgb(17 24 39 / 100%)')).toBe('#111827');
+    });
+
+    it('resolves percentage rgb() channels', () => {
+        expect(toMeasurableHex('rgb(0% 0% 0%)')).toBe('#000000');
+        expect(toMeasurableHex('rgb(100%, 100%, 100%)')).toBe('#ffffff');
+    });
+
+    it('rejects translucent rgb()', () => {
+        expect(toMeasurableHex('rgba(17, 24, 39, 0.5)')).toBeNull();
+        expect(toMeasurableHex('rgb(17 24 39 / 50%)')).toBeNull();
+        expect(toMeasurableHex('rgba(0, 0, 0, 0)')).toBeNull();
+    });
+
+    it('clamps out-of-range rgb() channels the way CSS does', () => {
+        expect(toMeasurableHex('rgb(300 -20 39)')).toBe('#ff0027');
+    });
+
+    it('resolves hsl()', () => {
+        expect(toMeasurableHex('hsl(0 0% 0%)')).toBe('#000000');
+        expect(toMeasurableHex('hsl(0, 0%, 100%)')).toBe('#ffffff');
+        expect(toMeasurableHex('hsl(0 100% 50%)')).toBe('#ff0000');
+        expect(toMeasurableHex('hsl(120 100% 50%)')).toBe('#00ff00');
+        expect(toMeasurableHex('hsl(240 100% 50%)')).toBe('#0000ff');
+    });
+
+    it('resolves hsl() hues in every CSS angle unit', () => {
+        expect(toMeasurableHex('hsl(120deg 100% 50%)')).toBe('#00ff00');
+        expect(toMeasurableHex('hsl(0.3333333turn 100% 50%)')).toBe('#00ff00');
+        expect(toMeasurableHex('hsl(133.3333grad 100% 50%)')).toBe('#00ff00');
+        expect(toMeasurableHex('hsl(2.0943951rad 100% 50%)')).toBe('#00ff00');
+    });
+
+    it('normalises hues outside 0–360', () => {
+        expect(toMeasurableHex('hsl(480 100% 50%)')).toBe('#00ff00');
+        expect(toMeasurableHex('hsl(-240 100% 50%)')).toBe('#00ff00');
+    });
+
+    it('rejects translucent hsl()', () => {
+        expect(toMeasurableHex('hsla(220, 39%, 11%, 0.5)')).toBeNull();
+    });
+
+    it('requires percentage units on hsl() saturation and lightness', () => {
+        expect(toMeasurableHex('hsl(220 39 11)')).toBeNull();
+    });
+
+    it('returns null for values that only resolve in the browser', () => {
+        expect(toMeasurableHex('var(--wp--preset--color--base)')).toBeNull();
+        expect(toMeasurableHex('color-mix(in srgb, #111827 50%, white)')).toBeNull();
+    });
+
+    it('returns null for malformed input', () => {
+        expect(toMeasurableHex('')).toBeNull();
+        expect(toMeasurableHex('   ')).toBeNull();
+        expect(toMeasurableHex('rgb(17, 24)')).toBeNull();
+        expect(toMeasurableHex('rgb(17, 24, 39, 1, 1)')).toBeNull();
+        expect(toMeasurableHex('rgb(a, b, c)')).toBeNull();
+        expect(toMeasurableHex('notacolor')).toBeNull();
+    });
+
+    it('tolerates surrounding whitespace', () => {
+        expect(toMeasurableHex('  #111827  ')).toBe('#111827');
+        expect(toMeasurableHex('  rgb( 17 , 24 , 39 )  ')).toBe('#111827');
+    });
+});

--- a/resources/js/visual-editor/editor/__tests__/editor-canvas.test.tsx
+++ b/resources/js/visual-editor/editor/__tests__/editor-canvas.test.tsx
@@ -13,7 +13,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
 
 const blockCanvasProps = vi.fn();
@@ -42,6 +42,26 @@ vi.mock('@wordpress/block-editor', () => ({
     ObserveTyping: ({ children }: { children: ReactNode }): JSX.Element => (
         <div data-testid="ap-stub-observe-typing">{children}</div>
     ),
+}));
+
+/*
+ * #695 — the canvas derives `--ap-editor-canvas-bg` / `-fg` from the
+ * resolved theme.json. Stub the global-styles settings hook so the
+ * tests can drive the payload without hitting the network; it defaults
+ * to the empty payload the real hook returns for an undefined `apiBase`.
+ */
+let mockThemeGlobalStyles: {
+    settings: Record<string, unknown>;
+    styles: Record<string, unknown>;
+} = { settings: {}, styles: {} };
+
+vi.mock('../../site-editor/use-theme-global-styles-settings', () => ({
+    useThemeGlobalStylesSettings: (): typeof mockThemeGlobalStyles =>
+        mockThemeGlobalStyles,
+}));
+
+vi.mock('../../site-editor/use-theme-global-styles-css', () => ({
+    useThemeGlobalStylesCss: (): string | undefined => undefined,
 }));
 
 vi.mock('../post-title', () => ({
@@ -347,6 +367,81 @@ describe('EditorCanvas', () => {
             expect(
                 screen.queryByTestId('ap-composed-view-ribbon-cta')
             ).not.toBeInTheDocument();
+        });
+    });
+
+    /*
+     * #695 — the iframe body is painted through `--ap-editor-canvas-bg`
+     * / `--ap-editor-canvas-fg`. Nothing supplied them, so a dark
+     * theme.json rendered a white canvas with invisible white headings.
+     * These cover the wiring: the tokens ride along in the styles array
+     * for a themed canvas, and stay absent otherwise.
+     */
+    describe('#695 canvas color tokens', () => {
+        afterEach(() => {
+            mockThemeGlobalStyles = { settings: {}, styles: {} };
+        });
+
+        function lastStyles(): { css: string }[] {
+            return blockCanvasProps.mock.calls.at(-1)?.[0].styles as {
+                css: string;
+            }[];
+        }
+
+        function renderCanvas(): void {
+            blockCanvasProps.mockClear();
+
+            render(
+                <EditorCanvas
+                    showTitle={false}
+                    title=""
+                    onTitleChange={() => undefined}
+                    blockContext={null}
+                    apiBase="/visual-editor/api"
+                />
+            );
+        }
+
+        it('appends the theme.json canvas colors as a :root entry', () => {
+            mockThemeGlobalStyles = {
+                settings: {},
+                styles: { color: { background: '#111827', text: '#FFFFFF' } },
+            };
+
+            renderCanvas();
+
+            const styles = lastStyles();
+            const tokens = styles.at(-1);
+
+            // Appended after the base bundle so it wins over the
+            // package baseline, and scoped to `:root` so a host rule on
+            // `body` / `.editor-styles-wrapper` still out-specifies it.
+            expect(styles.length).toBe(canvasStyles.length + 1);
+            expect(tokens?.css).toContain(':root {');
+            expect(tokens?.css).toContain('--ap-editor-canvas-bg: #111827;');
+            expect(tokens?.css).toContain('--ap-editor-canvas-fg: #FFFFFF;');
+        });
+
+        it('leaves the styles bundle untouched when the theme declares no colors', () => {
+            mockThemeGlobalStyles = { settings: {}, styles: {} };
+
+            renderCanvas();
+
+            // Identity, not just equality — nothing appended, so the
+            // `var()` fallbacks in `canvas-theme-tokens.css` still paint
+            // the canvas white with dark text.
+            expect(lastStyles()).toBe(canvasStyles);
+        });
+
+        it('emits no token entry for a theme whose colors are unusable', () => {
+            mockThemeGlobalStyles = {
+                settings: {},
+                styles: { color: { background: '', text: null } },
+            };
+
+            renderCanvas();
+
+            expect(lastStyles()).toBe(canvasStyles);
         });
     });
 });

--- a/resources/js/visual-editor/editor/canvas-color-tokens.ts
+++ b/resources/js/visual-editor/editor/canvas-color-tokens.ts
@@ -49,6 +49,7 @@
  */
 
 import type { CanvasStyle } from './canvas-styles';
+import { toMeasurableHex } from './css-color-parse';
 import {
     a11yGetContrastColor,
     getContrastRatio,
@@ -178,26 +179,40 @@ const HEADING_KEYS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
  *
  *   - returns `null` when the default is already legible, so the
  *     variable stays unset and nothing is emitted needlessly;
- *   - returns `null` for a background this can't measure (a `var()`
- *     preset reference resolves only in the browser), rather than
- *     guessing — a theme using presets has a resolved palette and in
- *     practice declares `text` alongside `background`;
+ *   - returns `null` for a background with no fixed opaque color — a
+ *     `var()` preset reference resolves only in the browser, and a
+ *     translucent color depends on whatever is painted behind it —
+ *     rather than guessing. A theme using presets has a resolved
+ *     palette and in practice declares `text` alongside `background`;
  *   - never runs when the theme declared a text color. An explicit
  *     low-contrast pairing is the theme's decision to make, and the
  *     canvas should render what the front end renders.
+ *
+ * The background is normalised through {@link toMeasurableHex} first.
+ * The WCAG helpers are hex-only (they mirror the PHP package one-for-one),
+ * but {@link ALLOWED_VALUE} admits every CSS color syntax — so measuring
+ * the raw value would silently skip derivation for `rgb(17 24 39)`,
+ * `hsl(220 39% 11%)`, `black`, and `#111827ff` alike, reinstating the
+ * unreadable-canvas bug for any theme that didn't happen to write hex.
  */
 function deriveForegroundFor(background: string | null): string | null {
     if (background === null) {
         return null;
     }
 
-    const ratio = getContrastRatio(DEFAULT_CANVAS_FG, background);
+    const measurable = toMeasurableHex(background);
+
+    if (measurable === null) {
+        return null;
+    }
+
+    const ratio = getContrastRatio(DEFAULT_CANVAS_FG, measurable);
 
     if (ratio === null || ratio >= WCAG_AA_NORMAL_TEXT_RATIO) {
         return null;
     }
 
-    return a11yGetContrastColor(background);
+    return a11yGetContrastColor(measurable);
 }
 
 /**

--- a/resources/js/visual-editor/editor/canvas-color-tokens.ts
+++ b/resources/js/visual-editor/editor/canvas-color-tokens.ts
@@ -35,6 +35,9 @@
  *
  *   - a theme declaring no colors leaves every variable unset and keeps
  *     the existing `#ffffff` / `#1f2937` / `#111827` defaults;
+ *   - a theme declaring a background but no text color gets a legible
+ *     foreground synthesized for it, because emitting half the pair
+ *     would reintroduce the very failure this module removes;
  *   - a theme that styles headings without a color leaves the heading
  *     variable unset, so headings inherit the canvas foreground rather
  *     than the light default;
@@ -46,6 +49,11 @@
  */
 
 import type { CanvasStyle } from './canvas-styles';
+import {
+    a11yGetContrastColor,
+    getContrastRatio,
+    WCAG_AA_NORMAL_TEXT_RATIO,
+} from './wcag-contrast';
 
 /**
  * Shape a theme.json color value has to match to be interpolated into
@@ -69,6 +77,38 @@ import type { CanvasStyle } from './canvas-styles';
  * Note `*` is absent, so `/*` can never form.
  */
 const ALLOWED_VALUE = /^[#\w(),.%/\s-]+$/;
+
+/**
+ * WordPress preset shorthand, e.g. `var:preset|color|base`.
+ *
+ * theme.json may reference a preset in either of two ways: the CSS form
+ * (`var(--wp--preset--color--base)`) or this pipe-delimited shorthand,
+ * which the WordPress handbook actually *recommends* over the CSS form.
+ * `/global-styles/base` hands back the theme manifest verbatim, so
+ * whichever form the theme author wrote is what arrives here.
+ *
+ * The shorthand is not CSS and would be rejected by {@link ALLOWED_VALUE},
+ * silently costing a theme its canvas colors — so it is rewritten to the
+ * CSS form first. The mapping is the same one WordPress applies:
+ * `var:<kind>|<feature>|<slug>` → `var(--wp--<kind>--<feature>--<slug>)`,
+ * covering `custom` (`var:custom|…`) as well as `preset`.
+ */
+const PRESET_REFERENCE = /^var:([\w-]+)\|([\w-]+)\|([\w-]+)$/;
+
+/**
+ * Rewrite WordPress's `var:preset|…` shorthand into the CSS custom
+ * property it denotes. Values that aren't shorthand pass through
+ * unchanged.
+ */
+function normalizePresetReference(value: string): string {
+    const match = PRESET_REFERENCE.exec(value);
+
+    if (match === null) {
+        return value;
+    }
+
+    return `var(--wp--${match[1]}--${match[2]}--${match[3]})`;
+}
 
 /**
  * Whether every `(` in a value is closed, so an interpolated value
@@ -104,7 +144,7 @@ function readColorValue(color: Record<string, unknown>, key: string): string | n
         return null;
     }
 
-    const value = raw.trim();
+    const value = normalizePresetReference(raw.trim());
 
     if (value === '' || !ALLOWED_VALUE.test(value) || !hasBalancedParens(value)) {
         return null;
@@ -113,8 +153,52 @@ function readColorValue(color: Record<string, unknown>, key: string): string | n
     return value;
 }
 
+/**
+ * The `var()` fallback `canvas-theme-tokens.css` paints body text with
+ * when `--ap-editor-canvas-fg` is unset. Mirrored here so this module
+ * can tell whether leaving the variable unset would actually be legible
+ * against a theme-supplied background — keep the two in step.
+ */
+const DEFAULT_CANVAS_FG = '#1f2937';
+
 /** Heading element keys a theme.json may carry a color on. */
 const HEADING_KEYS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
+
+/**
+ * Pick a legible foreground for a theme that declares a canvas
+ * background but no text color.
+ *
+ * Emitting the background alone would leave body text on the light
+ * `#1f2937` default and headings on `#111827` — invisible against a
+ * dark ground, which is the exact failure this whole change exists to
+ * remove. So when the theme leaves the other half of the pair open,
+ * fill it: black or white, whichever WCAG says reads better.
+ *
+ * Deliberately narrow:
+ *
+ *   - returns `null` when the default is already legible, so the
+ *     variable stays unset and nothing is emitted needlessly;
+ *   - returns `null` for a background this can't measure (a `var()`
+ *     preset reference resolves only in the browser), rather than
+ *     guessing — a theme using presets has a resolved palette and in
+ *     practice declares `text` alongside `background`;
+ *   - never runs when the theme declared a text color. An explicit
+ *     low-contrast pairing is the theme's decision to make, and the
+ *     canvas should render what the front end renders.
+ */
+function deriveForegroundFor(background: string | null): string | null {
+    if (background === null) {
+        return null;
+    }
+
+    const ratio = getContrastRatio(DEFAULT_CANVAS_FG, background);
+
+    if (ratio === null || ratio >= WCAG_AA_NORMAL_TEXT_RATIO) {
+        return null;
+    }
+
+    return a11yGetContrastColor(background);
+}
 
 /**
  * Read `elements.<key>.color.text` out of a theme.json `styles` node.
@@ -206,7 +290,10 @@ export function buildCanvasColorTokenCss(
             : {};
 
     const background = readColorValue(color, 'background');
-    const text = readColorValue(color, 'text');
+    // A background with no text color would otherwise leave body text on
+    // the light default and headings darker still — unreadable on a dark
+    // ground. Fill the missing half rather than emit half a pair.
+    const text = readColorValue(color, 'text') ?? deriveForegroundFor(background);
     const heading = readHeadingColor(themeStyles);
 
     if (background === null && text === null && heading === null) {

--- a/resources/js/visual-editor/editor/canvas-color-tokens.ts
+++ b/resources/js/visual-editor/editor/canvas-color-tokens.ts
@@ -1,0 +1,246 @@
+/**
+ * Canvas surface color bridge — #695.
+ *
+ * `canvas-theme-tokens.css` paints the iframe body through two
+ * package-owned custom properties:
+ *
+ *     body.editor-styles-wrapper {
+ *         background-color: var(--ap-editor-canvas-bg, #ffffff);
+ *         color: var(--ap-editor-canvas-fg, #1f2937);
+ *     }
+ *
+ * Nothing ever assigned those variables, so both resolved to the light
+ * fallbacks. Because that selector is an element+class compound
+ * (specificity 0,1,1) it also beats the theme's bare
+ * `.editor-styles-wrapper` rule (0,1,0) regardless of source order — so
+ * a dark theme.json painted a white canvas with dark body text no theme
+ * sheet could correct.
+ *
+ * `DEFAULT_CANVAS_STYLES` has the same shape of problem one level down:
+ * its `.editor-styles-wrapper h1..h6` rule (also 0,1,1) hardcodes
+ * `#111827`, out-specifying a theme's bare `h1`..`h6` selectors. Fixing
+ * only the ground would therefore have *moved* the bug — a dark canvas
+ * with headings pinned to near-black against it.
+ *
+ * This module closes both gaps by deriving three variables from the
+ * resolved theme.json `styles` node and emitting them as one `:root`
+ * rule appended to the canvas stylesheet list:
+ *
+ *   - `--ap-editor-canvas-bg`         ← `styles.color.background`
+ *   - `--ap-editor-canvas-fg`         ← `styles.color.text`
+ *   - `--ap-editor-canvas-heading-fg` ← `styles.elements.heading` /
+ *                                       `h1`..`h6` (see below)
+ *
+ * The painting rules themselves are unchanged, so:
+ *
+ *   - a theme declaring no colors leaves every variable unset and keeps
+ *     the existing `#ffffff` / `#1f2937` / `#111827` defaults;
+ *   - a theme that styles headings without a color leaves the heading
+ *     variable unset, so headings inherit the canvas foreground rather
+ *     than the light default;
+ *   - a host rule on `body` / `.editor-styles-wrapper` still out-specifies
+ *     this `:root` declaration and keeps its override.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since   1.6.0
+ */
+
+import type { CanvasStyle } from './canvas-styles';
+
+/**
+ * Shape a theme.json color value has to match to be interpolated into
+ * the emitted rule.
+ *
+ * This is a robustness guard, NOT a security boundary — theme.json is
+ * authored by the site's own theme, and the compiled theme stylesheet
+ * appended right after this entry in `editor-canvas.tsx` is arbitrary
+ * CSS from that same trust boundary. What this buys is a predictable
+ * failure mode: a typo'd value drops out and leaves its variable unset
+ * (so the `var()` fallbacks paint a readable canvas) rather than
+ * silently nullifying the whole `:root` rule.
+ *
+ * An allowlist rather than a denylist of `{};<>`, because two shapes
+ * slip past a denylist and take the entire rule down with them: an
+ * unterminated comment (`#111 /*`) and an unbalanced paren
+ * (`var(--x`) each swallow the rest of the stylesheet entry. The class
+ * below admits every shape this module documents — `#111827`,
+ * `rebeccapurple`, `var(--wp--preset--color--base)`,
+ * `rgb(0 0 0 / 50%)`, `color-mix(in srgb, …)` — and nothing else.
+ * Note `*` is absent, so `/*` can never form.
+ */
+const ALLOWED_VALUE = /^[#\w(),.%/\s-]+$/;
+
+/**
+ * Whether every `(` in a value is closed, so an interpolated value
+ * can't swallow the declarations that follow it.
+ */
+function hasBalancedParens(value: string): boolean {
+    let depth = 0;
+
+    for (const char of value) {
+        if (char === '(') {
+            depth += 1;
+        } else if (char === ')') {
+            depth -= 1;
+
+            if (depth < 0) {
+                return false;
+            }
+        }
+    }
+
+    return depth === 0;
+}
+
+/**
+ * Read a CSS color value out of a theme.json `styles.color` node.
+ * Returns `null` for anything that isn't a usable, safe string so the
+ * caller can leave the corresponding variable unset.
+ */
+function readColorValue(color: Record<string, unknown>, key: string): string | null {
+    const raw = color[key];
+
+    if (typeof raw !== 'string') {
+        return null;
+    }
+
+    const value = raw.trim();
+
+    if (value === '' || !ALLOWED_VALUE.test(value) || !hasBalancedParens(value)) {
+        return null;
+    }
+
+    return value;
+}
+
+/** Heading element keys a theme.json may carry a color on. */
+const HEADING_KEYS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
+
+/**
+ * Read `elements.<key>.color.text` out of a theme.json `styles` node.
+ */
+function readElementTextColor(
+    elements: Record<string, unknown>,
+    key: string
+): string | null {
+    const element = elements[key];
+
+    if (element === null || typeof element !== 'object' || Array.isArray(element)) {
+        return null;
+    }
+
+    const color = (element as { color?: unknown }).color;
+
+    if (color === null || typeof color !== 'object' || Array.isArray(color)) {
+        return null;
+    }
+
+    return readColorValue(color as Record<string, unknown>, 'text');
+}
+
+/**
+ * Resolve the heading color for the canvas baseline (#695).
+ *
+ * The package's `DEFAULT_CANVAS_STYLES` heading rule out-specifies a
+ * theme's bare `h1`..`h6` selectors, so headings have to arrive through
+ * a variable like the body colors do. Prefer the `heading` element
+ * group; fall back to `h1`..`h6` only when every level a theme declares
+ * agrees, since one variable cannot express divergent per-level colors
+ * — in that case the caller leaves it unset and headings inherit the
+ * canvas foreground.
+ */
+function readHeadingColor(themeStyles: Record<string, unknown>): string | null {
+    const elements = themeStyles.elements;
+
+    if (elements === null || typeof elements !== 'object' || Array.isArray(elements)) {
+        return null;
+    }
+
+    const node = elements as Record<string, unknown>;
+    const group = readElementTextColor(node, 'heading');
+
+    if (group !== null) {
+        return group;
+    }
+
+    const declared = HEADING_KEYS.map((key) => readElementTextColor(node, key)).filter(
+        (value): value is string => value !== null
+    );
+
+    if (declared.length === 0) {
+        return null;
+    }
+
+    return declared.every((value) => value === declared[0]) ? declared[0] : null;
+}
+
+/**
+ * Build the `:root` rule supplying the canvas color tokens from the
+ * resolved theme.json `styles` node (the `styles` half of the
+ * `/global-styles/base` payload).
+ *
+ * Returns `null` when the theme declares none of them, and omits any
+ * individual declaration it can't resolve — an unresolved variable must
+ * stay *unset* rather than be assigned an empty string, so the `var()`
+ * fallbacks in `canvas-theme-tokens.css` and `DEFAULT_CANVAS_STYLES`
+ * still apply.
+ *
+ * Values are passed through verbatim: theme.json commonly stores
+ * `var(--wp--preset--color--base)` references, and cms-framework's
+ * `GlobalStylesEmitter` defines those presets on `:root` inside the same
+ * document, so they resolve without further work.
+ */
+export function buildCanvasColorTokenCss(
+    themeStyles: Record<string, unknown> | undefined
+): string | null {
+    if (themeStyles === undefined) {
+        return null;
+    }
+
+    const node = themeStyles.color;
+    // A theme may declare heading colors without declaring canvas ones,
+    // so an absent / malformed `color` node isn't an early exit.
+    const color: Record<string, unknown> =
+        node !== null && typeof node === 'object' && !Array.isArray(node)
+            ? (node as Record<string, unknown>)
+            : {};
+
+    const background = readColorValue(color, 'background');
+    const text = readColorValue(color, 'text');
+    const heading = readHeadingColor(themeStyles);
+
+    if (background === null && text === null && heading === null) {
+        return null;
+    }
+
+    const declarations: string[] = [];
+
+    if (background !== null) {
+        declarations.push(`    --ap-editor-canvas-bg: ${background};`);
+    }
+
+    if (text !== null) {
+        declarations.push(`    --ap-editor-canvas-fg: ${text};`);
+    }
+
+    if (heading !== null) {
+        declarations.push(`    --ap-editor-canvas-heading-fg: ${heading};`);
+    }
+
+    return `:root {\n${declarations.join('\n')}\n}\n`;
+}
+
+/**
+ * {@link buildCanvasColorTokenCss} wrapped in the `{ css }` entry shape
+ * `BlockCanvas`'s `styles` prop expects. `null` when the theme supplies
+ * no canvas colors, so callers can skip appending an entry entirely.
+ *
+ * @see canvasStyles — the base list this entry is appended to.
+ */
+export function canvasColorTokenStyle(
+    themeStyles: Record<string, unknown> | undefined
+): CanvasStyle | null {
+    const css = buildCanvasColorTokenCss(themeStyles);
+
+    return css === null ? null : { css };
+}

--- a/resources/js/visual-editor/editor/canvas-theme-tokens.css
+++ b/resources/js/visual-editor/editor/canvas-theme-tokens.css
@@ -55,11 +55,24 @@
 
 /*
  * The iframe `<body>` carries the `editor-styles-wrapper` class. Pin its
- * surface to the canvas background token so the authoring surface stays
- * white regardless of the host admin theme — the parent-document rule
- * that used to do this (`.ap-visual-editor__canvas.editor-styles-wrapper`
- * in `editor-app.css`) no longer matches now that the styled surface
- * lives inside the iframe.
+ * surface to the canvas color tokens so the authoring surface is immune
+ * to the host admin theme — the parent-document rule that used to do
+ * this (`.ap-visual-editor__canvas.editor-styles-wrapper` in
+ * `editor-app.css`) no longer matches now that the styled surface lives
+ * inside the iframe.
+ *
+ * `--ap-editor-canvas-bg` / `--ap-editor-canvas-fg` are supplied from
+ * the resolved theme.json's `styles.color` by `canvas-color-tokens.ts`,
+ * appended to the canvas stylesheet list as a `:root` rule (#695). The
+ * hex fallbacks below stay in force when the theme declares no canvas
+ * colors, and a host rule on `body` / `.editor-styles-wrapper` still
+ * out-specifies that `:root` declaration.
+ *
+ * Note the compound `body.editor-styles-wrapper` selector (0,1,1) is
+ * deliberate — it has to beat the host admin theme. That means a theme
+ * sheet's bare `.editor-styles-wrapper` rule (0,1,0) cannot override it
+ * regardless of source order, which is exactly why the colors have to
+ * arrive through the variables rather than through the theme sheet.
  */
 body.editor-styles-wrapper {
     background-color: var(--ap-editor-canvas-bg, #ffffff);

--- a/resources/js/visual-editor/editor/css-color-parse.ts
+++ b/resources/js/visual-editor/editor/css-color-parse.ts
@@ -1,0 +1,443 @@
+/**
+ * Opaque CSS color → hex normalisation for contrast measurement (#695).
+ *
+ * `wcag-contrast.ts` deliberately parses only `#rgb` / `#rrggbb`, because
+ * it mirrors the `artisanpack-ui/accessibility` PHP helpers one-for-one
+ * and those are hex-only. That is the right contract for the block
+ * contrast warning, whose inputs come from Gutenberg color pickers and
+ * are always hex.
+ *
+ * theme.json is a different source. It is hand-authored as often as it
+ * is generated, and `styles.color.background` legitimately carries
+ * `rgb(17 24 39)`, `hsl(220 39% 11%)`, `black`, or `#111827ff` — every
+ * one of which `canvas-color-tokens.ts` accepts and emits, but none of
+ * which the hex-only parser can measure. Before this module existed the
+ * consequence was silent and severe: an unpaired dark background in any
+ * non-hex syntax emitted `--ap-editor-canvas-bg` while leaving
+ * `--ap-editor-canvas-fg` on the `#1f2937` default, reproducing the
+ * exact invisible-text failure #695 exists to remove.
+ *
+ * So this converts the opaque CSS color syntaxes to the `#rrggbb` form
+ * the contrast math understands, and returns `null` for anything it
+ * cannot resolve to a fixed opaque color:
+ *
+ *   - `var()` / `color-mix()` references, which resolve only in the
+ *     browser;
+ *   - translucent values (alpha < 1), whose rendered color depends on
+ *     whatever is painted behind them;
+ *   - `currentColor`, `inherit`, `transparent`, and typos.
+ *
+ * Kept local to the editor rather than folded into `wcag-contrast.ts` so
+ * the contrast-warning contract stays a faithful port of the PHP side.
+ *
+ * @package @artisanpack-ui/visual-editor
+ * @since   1.6.0
+ */
+
+interface RGBTriple {
+    readonly r: number;
+    readonly g: number;
+    readonly b: number;
+}
+
+/**
+ * CSS Color Module Level 4 named colors.
+ *
+ * The full table rather than a convenient subset — a partial list fails
+ * exactly the way the hex-only parser did, silently and only for the
+ * themes unlucky enough to use a name that didn't make the cut.
+ * `transparent` is intentionally absent: it is not an opaque color.
+ */
+const NAMED_COLORS: Readonly<Record<string, string>> = {
+    aliceblue: '#f0f8ff',
+    antiquewhite: '#faebd7',
+    aqua: '#00ffff',
+    aquamarine: '#7fffd4',
+    azure: '#f0ffff',
+    beige: '#f5f5dc',
+    bisque: '#ffe4c4',
+    black: '#000000',
+    blanchedalmond: '#ffebcd',
+    blue: '#0000ff',
+    blueviolet: '#8a2be2',
+    brown: '#a52a2a',
+    burlywood: '#deb887',
+    cadetblue: '#5f9ea0',
+    chartreuse: '#7fff00',
+    chocolate: '#d2691e',
+    coral: '#ff7f50',
+    cornflowerblue: '#6495ed',
+    cornsilk: '#fff8dc',
+    crimson: '#dc143c',
+    cyan: '#00ffff',
+    darkblue: '#00008b',
+    darkcyan: '#008b8b',
+    darkgoldenrod: '#b8860b',
+    darkgray: '#a9a9a9',
+    darkgreen: '#006400',
+    darkgrey: '#a9a9a9',
+    darkkhaki: '#bdb76b',
+    darkmagenta: '#8b008b',
+    darkolivegreen: '#556b2f',
+    darkorange: '#ff8c00',
+    darkorchid: '#9932cc',
+    darkred: '#8b0000',
+    darksalmon: '#e9967a',
+    darkseagreen: '#8fbc8f',
+    darkslateblue: '#483d8b',
+    darkslategray: '#2f4f4f',
+    darkslategrey: '#2f4f4f',
+    darkturquoise: '#00ced1',
+    darkviolet: '#9400d3',
+    deeppink: '#ff1493',
+    deepskyblue: '#00bfff',
+    dimgray: '#696969',
+    dimgrey: '#696969',
+    dodgerblue: '#1e90ff',
+    firebrick: '#b22222',
+    floralwhite: '#fffaf0',
+    forestgreen: '#228b22',
+    fuchsia: '#ff00ff',
+    gainsboro: '#dcdcdc',
+    ghostwhite: '#f8f8ff',
+    gold: '#ffd700',
+    goldenrod: '#daa520',
+    gray: '#808080',
+    green: '#008000',
+    greenyellow: '#adff2f',
+    grey: '#808080',
+    honeydew: '#f0fff0',
+    hotpink: '#ff69b4',
+    indianred: '#cd5c5c',
+    indigo: '#4b0082',
+    ivory: '#fffff0',
+    khaki: '#f0e68c',
+    lavender: '#e6e6fa',
+    lavenderblush: '#fff0f5',
+    lawngreen: '#7cfc00',
+    lemonchiffon: '#fffacd',
+    lightblue: '#add8e6',
+    lightcoral: '#f08080',
+    lightcyan: '#e0ffff',
+    lightgoldenrodyellow: '#fafad2',
+    lightgray: '#d3d3d3',
+    lightgreen: '#90ee90',
+    lightgrey: '#d3d3d3',
+    lightpink: '#ffb6c1',
+    lightsalmon: '#ffa07a',
+    lightseagreen: '#20b2aa',
+    lightskyblue: '#87cefa',
+    lightslategray: '#778899',
+    lightslategrey: '#778899',
+    lightsteelblue: '#b0c4de',
+    lightyellow: '#ffffe0',
+    lime: '#00ff00',
+    limegreen: '#32cd32',
+    linen: '#faf0e6',
+    magenta: '#ff00ff',
+    maroon: '#800000',
+    mediumaquamarine: '#66cdaa',
+    mediumblue: '#0000cd',
+    mediumorchid: '#ba55d3',
+    mediumpurple: '#9370db',
+    mediumseagreen: '#3cb371',
+    mediumslateblue: '#7b68ee',
+    mediumspringgreen: '#00fa9a',
+    mediumturquoise: '#48d1cc',
+    mediumvioletred: '#c71585',
+    midnightblue: '#191970',
+    mintcream: '#f5fffa',
+    mistyrose: '#ffe4e1',
+    moccasin: '#ffe4b5',
+    navajowhite: '#ffdead',
+    navy: '#000080',
+    oldlace: '#fdf5e6',
+    olive: '#808000',
+    olivedrab: '#6b8e23',
+    orange: '#ffa500',
+    orangered: '#ff4500',
+    orchid: '#da70d6',
+    palegoldenrod: '#eee8aa',
+    palegreen: '#98fb98',
+    paleturquoise: '#afeeee',
+    palevioletred: '#db7093',
+    papayawhip: '#ffefd5',
+    peachpuff: '#ffdab9',
+    peru: '#cd853f',
+    pink: '#ffc0cb',
+    plum: '#dda0dd',
+    powderblue: '#b0e0e6',
+    purple: '#800080',
+    rebeccapurple: '#663399',
+    red: '#ff0000',
+    rosybrown: '#bc8f8f',
+    royalblue: '#4169e1',
+    saddlebrown: '#8b4513',
+    salmon: '#fa8072',
+    sandybrown: '#f4a460',
+    seagreen: '#2e8b57',
+    seashell: '#fff5ee',
+    sienna: '#a0522d',
+    silver: '#c0c0c0',
+    skyblue: '#87ceeb',
+    slateblue: '#6a5acd',
+    slategray: '#708090',
+    slategrey: '#708090',
+    snow: '#fffafa',
+    springgreen: '#00ff7f',
+    steelblue: '#4682b4',
+    tan: '#d2b48c',
+    teal: '#008080',
+    thistle: '#d8bfd8',
+    tomato: '#ff6347',
+    turquoise: '#40e0d0',
+    violet: '#ee82ee',
+    wheat: '#f5deb3',
+    white: '#ffffff',
+    whitesmoke: '#f5f5f5',
+    yellow: '#ffff00',
+    yellowgreen: '#9acd32',
+};
+
+const HEX_DIGITS = /^#([0-9a-f]+)$/i;
+const FUNCTIONAL = /^(rgba?|hsla?)\(([^)]*)\)$/i;
+const NUMBER = /^[+-]?(?:\d+\.?\d*|\.\d+)$/;
+const ANGLE = /^([+-]?(?:\d+\.?\d*|\.\d+))(deg|grad|rad|turn)?$/i;
+const PERCENTAGE = /^([+-]?(?:\d+\.?\d*|\.\d+))%$/;
+
+function clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
+}
+
+function toHexPair(channel: number): string {
+    return clamp(Math.round(channel), 0, 255).toString(16).padStart(2, '0');
+}
+
+function toHex(rgb: RGBTriple): string {
+    return `#${toHexPair(rgb.r)}${toHexPair(rgb.g)}${toHexPair(rgb.b)}`;
+}
+
+function expandShorthand(digits: string): string {
+    return digits
+        .split('')
+        .map((character) => character + character)
+        .join('');
+}
+
+/**
+ * Hex in any of the four CSS lengths. The alpha-bearing forms resolve
+ * only when fully opaque — a translucent color has no fixed rendered
+ * value to measure.
+ */
+function fromHex(value: string): string | null {
+    const match = HEX_DIGITS.exec(value);
+
+    if (match === null) {
+        return null;
+    }
+
+    const digits = match[1].toLowerCase();
+
+    if (digits.length === 3) {
+        return `#${expandShorthand(digits)}`;
+    }
+
+    if (digits.length === 4) {
+        return digits[3] === 'f' ? `#${expandShorthand(digits.slice(0, 3))}` : null;
+    }
+
+    if (digits.length === 6) {
+        return `#${digits}`;
+    }
+
+    if (digits.length === 8) {
+        return digits.slice(6) === 'ff' ? `#${digits.slice(0, 6)}` : null;
+    }
+
+    return null;
+}
+
+/**
+ * An `rgb()` color channel: `0`–`255`, or a percentage of 255.
+ */
+function parseRgbChannel(token: string): number | null {
+    const percentage = PERCENTAGE.exec(token);
+
+    if (percentage !== null) {
+        return clamp((Number(percentage[1]) * 255) / 100, 0, 255);
+    }
+
+    if (!NUMBER.test(token)) {
+        return null;
+    }
+
+    return clamp(Number(token), 0, 255);
+}
+
+/**
+ * An alpha channel, as a `0`–`1` number or a percentage. Anything short
+ * of fully opaque returns `null` from the callers — see {@link fromHex}.
+ */
+function parseAlpha(token: string): number | null {
+    const percentage = PERCENTAGE.exec(token);
+
+    if (percentage !== null) {
+        return clamp(Number(percentage[1]) / 100, 0, 1);
+    }
+
+    if (!NUMBER.test(token)) {
+        return null;
+    }
+
+    return clamp(Number(token), 0, 1);
+}
+
+/** A hue, in any of the CSS angle units, normalised to degrees. */
+function parseHue(token: string): number | null {
+    const match = ANGLE.exec(token);
+
+    if (match === null) {
+        return null;
+    }
+
+    const value = Number(match[1]);
+
+    switch ((match[2] ?? 'deg').toLowerCase()) {
+        case 'deg':
+            return value;
+        case 'grad':
+            return value * 0.9;
+        case 'rad':
+            return (value * 180) / Math.PI;
+        case 'turn':
+            return value * 360;
+        default:
+            return null;
+    }
+}
+
+function hslToRgb(hue: number, saturation: number, lightness: number): RGBTriple {
+    const normalisedHue = ((hue % 360) + 360) % 360;
+    const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+    const secondary = chroma * (1 - Math.abs(((normalisedHue / 60) % 2) - 1));
+    const offset = lightness - chroma / 2;
+
+    let r = 0;
+    let g = 0;
+    let b = 0;
+
+    if (normalisedHue < 60) {
+        r = chroma;
+        g = secondary;
+    } else if (normalisedHue < 120) {
+        r = secondary;
+        g = chroma;
+    } else if (normalisedHue < 180) {
+        g = chroma;
+        b = secondary;
+    } else if (normalisedHue < 240) {
+        g = secondary;
+        b = chroma;
+    } else if (normalisedHue < 300) {
+        r = secondary;
+        b = chroma;
+    } else {
+        r = chroma;
+        b = secondary;
+    }
+
+    return {
+        r: (r + offset) * 255,
+        g: (g + offset) * 255,
+        b: (b + offset) * 255,
+    };
+}
+
+/**
+ * Split the inside of an `rgb()` / `hsl()` call into its arguments.
+ * Handles both the legacy comma syntax (`rgb(0, 0, 0)`) and the modern
+ * space syntax with a slash-delimited alpha (`rgb(0 0 0 / 50%)`).
+ */
+function splitArguments(inner: string): string[] {
+    return inner
+        .trim()
+        .split(/[\s,/]+/)
+        .filter((token) => token !== '');
+}
+
+function fromFunctional(value: string): string | null {
+    const match = FUNCTIONAL.exec(value);
+
+    if (match === null) {
+        return null;
+    }
+
+    const fn = match[1].toLowerCase();
+    const args = splitArguments(match[2]);
+
+    if (args.length < 3 || args.length > 4) {
+        return null;
+    }
+
+    if (args.length === 4) {
+        const alpha = parseAlpha(args[3]);
+
+        // A translucent color renders against whatever sits behind it,
+        // so there is no single value to measure contrast against.
+        if (alpha === null || alpha < 1) {
+            return null;
+        }
+    }
+
+    if (fn === 'rgb' || fn === 'rgba') {
+        const channels = args.slice(0, 3).map(parseRgbChannel);
+
+        if (channels.some((channel) => channel === null)) {
+            return null;
+        }
+
+        return toHex({
+            r: channels[0] as number,
+            g: channels[1] as number,
+            b: channels[2] as number,
+        });
+    }
+
+    const hue = parseHue(args[0]);
+    const saturation = PERCENTAGE.exec(args[1]);
+    const lightness = PERCENTAGE.exec(args[2]);
+
+    if (hue === null || saturation === null || lightness === null) {
+        return null;
+    }
+
+    return toHex(
+        hslToRgb(
+            hue,
+            clamp(Number(saturation[1]) / 100, 0, 1),
+            clamp(Number(lightness[1]) / 100, 0, 1)
+        )
+    );
+}
+
+/**
+ * Resolve an opaque CSS color to `#rrggbb` so the WCAG helpers can
+ * measure it. Returns `null` for values with no fixed opaque color —
+ * `var()` references, translucent colors, keywords like `currentColor`,
+ * and anything malformed.
+ */
+export function toMeasurableHex(value: string): string | null {
+    const trimmed = value.trim();
+
+    if (trimmed === '') {
+        return null;
+    }
+
+    const named = NAMED_COLORS[trimmed.toLowerCase()];
+
+    if (named !== undefined) {
+        return named;
+    }
+
+    return fromHex(trimmed) ?? fromFunctional(trimmed);
+}

--- a/resources/js/visual-editor/editor/editor-app.css
+++ b/resources/js/visual-editor/editor/editor-app.css
@@ -107,9 +107,10 @@
  * The canvas *surface* background is now painted inside the iframe via
  * `canvas-theme-tokens.css` — the parent-document rule that used to do
  * it (`.ap-visual-editor__canvas.editor-styles-wrapper`) can't reach
- * the iframe document. Hosts still override `--ap-editor-canvas-bg` /
- * `--ap-editor-canvas-fg`; once the theme.json reader lands it'll
- * supply these from `settings.color.background`.
+ * the iframe document. Those tokens (`--ap-editor-canvas-bg` /
+ * `--ap-editor-canvas-fg`) are supplied from the resolved theme.json's
+ * `styles.color` by `canvas-color-tokens.ts` (#695); hosts still
+ * override them with a rule on `body` / `.editor-styles-wrapper`.
  */
 .ap-visual-editor__canvas-frame {
     flex: 1 1 auto;

--- a/resources/js/visual-editor/editor/editor-canvas.tsx
+++ b/resources/js/visual-editor/editor/editor-canvas.tsx
@@ -39,6 +39,7 @@ import { __ } from '@wordpress/i18n';
 import type { BlockInstance } from '@wordpress/blocks';
 import { useMemo } from 'react';
 
+import { canvasColorTokenStyle } from './canvas-color-tokens';
 import { canvasStyles } from './canvas-styles';
 import { ChromeBlocks } from './composed-view/ChromeBlocks';
 import { ComposedViewRibbon } from './composed-view/composed-view-ribbon';
@@ -46,6 +47,7 @@ import { PostTitle } from './post-title';
 import { ROOT_CANVAS_LAYOUT } from '../editor-settings';
 import { TEXT_DOMAIN } from '../vendor/i18n';
 import { useThemeGlobalStylesCss } from '../site-editor/use-theme-global-styles-css';
+import { useThemeGlobalStylesSettings } from '../site-editor/use-theme-global-styles-settings';
 
 /**
  * Applied-template chrome to render around the block list (#655). Already
@@ -137,13 +139,36 @@ export function EditorCanvas(props: EditorCanvasProps): JSX.Element {
     // module-level so multiple consumers (site editor + post editor)
     // share one fetch when mounted in the same SPA session.
     const themeCss = useThemeGlobalStylesCss(apiBase);
-    const styles = useMemo(
-        () =>
-            themeCss === undefined || themeCss === ''
-                ? canvasStyles
-                : [...canvasStyles, { css: themeCss }],
-        [themeCss]
+
+    // #695 — the canvas surface is painted through package-owned custom
+    // properties (`--ap-editor-canvas-bg` / `-fg` in
+    // `canvas-theme-tokens.css`, `-heading-fg` in
+    // `DEFAULT_CANVAS_STYLES`) that nothing supplied, so a dark
+    // theme.json still rendered a light canvas. Derive them from the
+    // resolved theme and inject them as a `:root` rule. It lands
+    // *before* the compiled theme CSS so a theme's own `editor.css` can
+    // still override the variables directly, and stays at `:root` so a
+    // host rule on `body` / `.editor-styles-wrapper` keeps
+    // out-specifying it.
+    const themeBase = useThemeGlobalStylesSettings(apiBase);
+    const colorTokens = useMemo(
+        () => canvasColorTokenStyle(themeBase?.styles),
+        [themeBase]
     );
+
+    const styles = useMemo(() => {
+        if (colorTokens === null && (themeCss === undefined || themeCss === '')) {
+            return canvasStyles;
+        }
+
+        return [
+            ...canvasStyles,
+            ...(colorTokens === null ? [] : [colorTokens]),
+            ...(themeCss === undefined || themeCss === ''
+                ? []
+                : [{ css: themeCss }]),
+        ];
+    }, [themeCss, colorTokens]);
 
     // Chrome sits as siblings of the block list inside the iframe. The
     // previews mount isolated block-editor stores of their own, so the


### PR DESCRIPTION
## Description

The post-editor canvas rendered a white ground with dark body text no matter what the active theme declared, so a dark `theme.json` produced an authoring surface that looked nothing like the front end.

`canvas-theme-tokens.css` paints the iframe body through two package-owned custom properties:

```css
body.editor-styles-wrapper {
    background-color: var(--ap-editor-canvas-bg, #ffffff);
    color: var(--ap-editor-canvas-fg, #1f2937);
}
```

Nothing ever assigned them, so both resolved to the light fallbacks — and because that selector is an element+class compound (0,1,1) it out-specifies a theme's bare `.editor-styles-wrapper` rule (0,1,0) regardless of source order, so no theme sheet could correct it. The comment in `editor-app.css` had promised these would be supplied "once the theme.json reader lands"; the reader landed with Keystone #47 but the wiring never followed.

**Closes:** #695

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #695

## Motivation and Context

Authors on a dark theme could not see what they were writing: the canvas contradicted the front end, and heading blocks left blank gaps in the document.

Note the scope grew by one defect during manual testing. `DEFAULT_CANVAS_STYLES` carried the *same* bug one level down — its `.editor-styles-wrapper h1..h6` rule (also 0,1,1) hardcoded `#111827`, which a theme's bare `h1`..`h6` selectors cannot override. Fixing only the ground moved the bug rather than closing it: with a theme whose `base` is `#111827`, the canvas correctly went dark and the headings then rendered near-invisible *against* it. Both halves are fixed here, which is what the issue's "headings remain legible" acceptance criterion requires.

## Changes Made

- **New `editor/canvas-color-tokens.ts`** — derives `--ap-editor-canvas-bg` / `--ap-editor-canvas-fg` from the resolved theme.json's `styles.color`, and `--ap-editor-canvas-heading-fg` from `styles.elements.heading` (falling back to `h1`..`h6` when every declared level agrees). Emits one `:root` rule, or `null` when the theme declares nothing.
- **`editor/editor-canvas.tsx`** — reads the payload via the existing `useThemeGlobalStylesSettings(apiBase)` hook and appends the token entry to the canvas `styles` array, positioned after `canvasStyles` but *before* the compiled theme CSS so a theme's own `editor.css` can still override the variables directly.
- **`editor-settings.ts`** — the `h1`..`h6` baseline now chains `var(--ap-editor-canvas-heading-fg, var(--ap-editor-canvas-fg, #111827))` instead of hardcoding the hex.
- **`canvas-theme-tokens.css` / `editor-app.css`** — comment updates only; both painting rules are unchanged, which is what preserves the host-override contract.
- **`CHANGELOG.md`** — `[Unreleased] / Fixed` entry.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- Browser (if applicable): Safari
- PHP Version: 8.4.3
- Project Version: reproduced against `visual-editor` 1.5.5 with `cms-framework` 2.7.2

**Tests Performed:**

1. Built a v1.5.5 bundle carrying only this fix and installed it into the affected app, so the fix was exercised against the exact install where the bug was found rather than a synthetic case.
2. Post editor with a dark theme (`base` `#111827`, `text` `#FFFFFF`, headings styled with typography only): canvas renders on the theme's dark ground with white body text, and heading blocks are legible instead of leaving blank gaps. Confirmed the pre-fix behavior first, and confirmed the intermediate state where only the ground was fixed and headings went invisible — which is how the second defect was found.
3. Site editor with the same theme: unchanged.
4. `npm test` — 3097 tests across 332 files passing.
5. `tsc --noEmit` — no new errors in the changed files.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [x] Color contrast verified
- [ ] ARIA labels checked

**Details:** This is a contrast fix at heart — the reported symptom was body text and headings rendering against a ground they were never paired with. Verified in-browser that body text and headings both read from the theme's `text` color against the theme's `background`, so the canvas now inherits whatever contrast the theme itself was designed for rather than a package default fighting it.

Also confirmed no regression to the existing contrast tooling: `contrast-warning.tsx` only fires when a block sets *both* text and background explicitly, so it never assumed the canvas ground and is unaffected by the ground changing.

Not run: keyboard navigation, screen reader, and ARIA — this change adds no interactive affordance, no focus order, and no markup; it only supplies values to two existing CSS declarations.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `editor/__tests__/canvas-color-tokens.test.ts` (new, 17 cases) — the dark-theme case; `var()` preset references passed through verbatim; the no-`styles.color` case leaving variables *unset* rather than empty; heading resolution via the `heading` group, via agreeing `h1`..`h6`, and the divergent-levels case that deliberately leaves the token unset; and value rejection.
- `editor/__tests__/editor-canvas.test.tsx` — three wiring cases asserting the token entry is appended for a themed canvas, and that the bundle is returned *by identity* (nothing appended) when the theme declares no colors or only unusable ones.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** New module carries a full docblock explaining the two-level specificity problem and why the colors must arrive through variables rather than a theme sheet. The stale "once the theme.json reader lands it'll supply these" comment in `editor-app.css` and the matching note in `canvas-theme-tokens.css` are now accurate.

## Screenshots

Verified in-browser on the reporting install; see the issue for the pre-fix capture.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Security note

A security review was run over the diff, since this interpolates theme-supplied values into CSS injected into the editor iframe. Result: **nothing exploitable.**

The sink is a React text child of a `<style>` element (`EditorStyles` → `transformStyles` short-circuits with no scope/baseURL, so the CSS passes through verbatim into `textContent`, never `innerHTML`), so `</style>` cannot break out regardless of the guard. `background-color` accepts no `<url>`, so there is no fetching primitive and no exfiltration vector.

The review did flag that a naive `[{};<>]` denylist lets two shapes through — an unterminated comment (`#111 /*`) and an unbalanced paren (`var(--x`) — each of which swallows the rest of the stylesheet entry. Not a security issue (escaping the block still requires a literal `}`), but a confusing failure mode: the theme's colors would silently stop applying wholesale. That guard is now an allowlist plus a paren-balance check, so a bad value drops out on its own and leaves the rest of the rule intact. Both shapes have regression tests.

To be explicit about the trust model: this guard is robustness, not a security boundary. The compiled theme stylesheet appended immediately after this entry is arbitrary CSS from the same trust boundary (the site's own theme), and it should not be relied on as a sanitizer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Post-editor canvas backgrounds, text, and headings now reflect colors configured in the active theme.
  * Added support for theme preset color formats and automatic contrasting text when needed.
  * Invalid or unavailable theme colors now fall back safely without disrupting the canvas.
  * Existing host styling continues to take precedence, and site-editor behavior remains unchanged.

* **Documentation**
  * Clarified how canvas theme colors are applied, prioritized, and overridden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->