### PR TITLE
fix: scope site-editor theme global styles to the canvas

### DIFF
--- a/resources/js/visual-editor/site-editor/__tests__/canvas-theme-styles.test.tsx
+++ b/resources/js/visual-editor/site-editor/__tests__/canvas-theme-styles.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * #679 — regression cover for the `<style>` tag the site-editor canvas
+ * injects. The emitter ships theme.json root spacing on `:root`; with
+ * the editor mounted inline that selector matches the host document's
+ * `<html>`, so the injected CSS must be scoped to the canvas surface
+ * before it reaches the DOM.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../use-theme-global-styles-css', () => ({
+    useThemeGlobalStylesCss: vi.fn(),
+}));
+
+import { useThemeGlobalStylesCss as useThemeGlobalStylesCssRaw } from '../use-theme-global-styles-css';
+
+const USE_THEME_GLOBAL_STYLES_CSS = vi.mocked(useThemeGlobalStylesCssRaw);
+
+import { CanvasThemeStyles } from '../canvas-theme-styles';
+import { CANVAS_SCOPE_SELECTOR } from '../scope-global-styles-css';
+
+describe('CanvasThemeStyles', () => {
+    beforeEach(() => {
+        USE_THEME_GLOBAL_STYLES_CSS.mockReset();
+    });
+
+    it('injects the theme CSS with `:root` scoped to the canvas surface', () => {
+        USE_THEME_GLOBAL_STYLES_CSS.mockReturnValue(
+            ':root { padding: 2rem 1.5rem; --wp--preset--color--primary: #2563eb; }'
+        );
+
+        render(<CanvasThemeStyles apiBase="/visual-editor/api" />);
+
+        const style = screen.getByTestId('ap-canvas-theme-styles');
+
+        expect(style.textContent).toBe(
+            `${CANVAS_SCOPE_SELECTOR} { padding: 2rem 1.5rem; --wp--preset--color--primary: #2563eb; }`
+        );
+        expect(style.textContent).not.toContain(':root');
+    });
+
+    it('renders nothing while the fetch is in flight', () => {
+        USE_THEME_GLOBAL_STYLES_CSS.mockReturnValue(undefined);
+
+        render(<CanvasThemeStyles apiBase="/visual-editor/api" />);
+
+        expect(screen.queryByTestId('ap-canvas-theme-styles')).toBeNull();
+    });
+
+    it('renders nothing when the theme has no global styles', () => {
+        USE_THEME_GLOBAL_STYLES_CSS.mockReturnValue('');
+
+        render(<CanvasThemeStyles apiBase="/visual-editor/api" />);
+
+        expect(screen.queryByTestId('ap-canvas-theme-styles')).toBeNull();
+    });
+});

--- a/resources/js/visual-editor/site-editor/__tests__/scope-global-styles-css.test.ts
+++ b/resources/js/visual-editor/site-editor/__tests__/scope-global-styles-css.test.ts
@@ -1,0 +1,107 @@
+/**
+ * #679 — the site editor mounts inline, so the global-styles emitter's
+ * `:root` rules land on the host document's `<html>`. These tests pin
+ * the rewrite that scopes them to the canvas surface instead.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    CANVAS_SCOPE_SELECTOR,
+    scopeGlobalStylesCss,
+} from '../scope-global-styles-css';
+
+describe('scopeGlobalStylesCss', () => {
+    it('rewrites a root rule carrying theme padding to the canvas scope', () => {
+        const css = ':root {\n    padding: 2rem 1.5rem;\n}';
+
+        const scoped = scopeGlobalStylesCss(css);
+
+        expect(scoped).toBe(
+            `${CANVAS_SCOPE_SELECTOR} {\n    padding: 2rem 1.5rem;\n}`
+        );
+        expect(scoped).not.toContain(':root');
+    });
+
+    it('keeps preset tokens resolvable by moving them to the canvas scope', () => {
+        const css =
+            ':root { --wp--preset--color--primary: #2563eb; }\n' +
+            '.wp-block-button { color: var(--wp--preset--color--primary); }';
+
+        expect(scopeGlobalStylesCss(css)).toBe(
+            `${CANVAS_SCOPE_SELECTOR} { --wp--preset--color--primary: #2563eb; }\n` +
+                '.wp-block-button { color: var(--wp--preset--color--primary); }'
+        );
+    });
+
+    it('rewrites every occurrence, including inside at-rules and selector lists', () => {
+        const css =
+            '@media (min-width: 600px) { :root { padding: 3rem; } }\n' +
+            ':root, .wp-site-blocks { margin: 0; }\n' +
+            ':root .wp-block-group { gap: 1rem; }';
+
+        const scoped = scopeGlobalStylesCss(css);
+
+        expect(scoped).toBe(
+            `@media (min-width: 600px) { ${CANVAS_SCOPE_SELECTOR} { padding: 3rem; } }\n` +
+                `${CANVAS_SCOPE_SELECTOR}, .wp-site-blocks { margin: 0; }\n` +
+                `${CANVAS_SCOPE_SELECTOR} .wp-block-group { gap: 1rem; }`
+        );
+    });
+
+    it('leaves `:root` mentions inside comments and strings alone', () => {
+        const css =
+            '/* tokens declared on :root by the emitter */\n' +
+            '.wp-block-note::before { content: ":root"; }\n' +
+            ".wp-block-hero { background: url('/img/:root.png'); }";
+
+        expect(scopeGlobalStylesCss(css)).toBe(css);
+    });
+
+    it('leaves an unquoted data URI carrying its own `:root` styles alone', () => {
+        const css =
+            '.wp-block-hero { background: url(data:image/svg+xml,<svg><style>:root{fill:red}</style></svg>); }';
+
+        expect(scopeGlobalStylesCss(css)).toBe(css);
+    });
+
+    it('still rewrites selectors that follow a url() value', () => {
+        const css =
+            '.a { background: url(/img/a.png); }\n:root { padding: 1rem; }';
+
+        expect(scopeGlobalStylesCss(css)).toBe(
+            `.a { background: url(/img/a.png); }\n${CANVAS_SCOPE_SELECTOR} { padding: 1rem; }`
+        );
+    });
+
+    it('handles a quoted url() containing a closing paren', () => {
+        const css =
+            '.a { background: url( "/img/a(1).png" ); }\n:root { padding: 1rem; }';
+
+        expect(scopeGlobalStylesCss(css)).toBe(
+            `.a { background: url( "/img/a(1).png" ); }\n${CANVAS_SCOPE_SELECTOR} { padding: 1rem; }`
+        );
+    });
+
+    it('does not touch identifiers that merely start with `:root`', () => {
+        const css = ':rooted { color: red; }';
+
+        expect(scopeGlobalStylesCss(css)).toBe(css);
+    });
+
+    it('returns empty CSS untouched', () => {
+        expect(scopeGlobalStylesCss('')).toBe('');
+    });
+
+    it('tolerates an unterminated string without dropping input', () => {
+        const css = '.a { content: "unterminated';
+
+        expect(scopeGlobalStylesCss(css)).toBe(css);
+    });
+
+    it('tolerates an unterminated comment without dropping input', () => {
+        const css = '.a { color: red; } /* trailing :root note';
+
+        expect(scopeGlobalStylesCss(css)).toBe(css);
+    });
+});

--- a/resources/js/visual-editor/site-editor/canvas-theme-styles.tsx
+++ b/resources/js/visual-editor/site-editor/canvas-theme-styles.tsx
@@ -17,11 +17,19 @@
  * cascade order so emitter rules declare `--wp--preset--*` tokens
  * and the hand-authored sheet consumes / overrides them.
  *
+ * The emitter's `:root` selectors are rewritten to the canvas scope
+ * selector before injection ({@see scopeGlobalStylesCss}) — inline
+ * mounting makes `:root` the host document's `<html>`, so the theme's
+ * root spacing would otherwise push the whole editor shell in (#679).
+ *
  * Renders nothing when no `apiBase` is wired, when the fetch is
  * still in flight, or when the response was empty — the canvas
  * stays on `DEFAULT_CANVAS_STYLES` as the floor.
  */
 
+import { useMemo } from 'react';
+
+import { scopeGlobalStylesCss } from './scope-global-styles-css';
 import { useThemeGlobalStylesCss } from './use-theme-global-styles-css';
 
 export interface CanvasThemeStylesProps {
@@ -35,10 +43,14 @@ export interface CanvasThemeStylesProps {
 
 export function CanvasThemeStyles(props: CanvasThemeStylesProps): JSX.Element | null {
     const css = useThemeGlobalStylesCss(props.apiBase);
+    const scopedCss = useMemo(
+        () => (css === undefined ? undefined : scopeGlobalStylesCss(css)),
+        [css]
+    );
 
-    if (css === undefined || css === '') {
+    if (scopedCss === undefined || scopedCss === '') {
         return null;
     }
 
-    return <style data-testid="ap-canvas-theme-styles">{css}</style>;
+    return <style data-testid="ap-canvas-theme-styles">{scopedCss}</style>;
 }

--- a/resources/js/visual-editor/site-editor/scope-global-styles-css.ts
+++ b/resources/js/visual-editor/site-editor/scope-global-styles-css.ts
@@ -1,0 +1,176 @@
+/**
+ * Rewrites the `:root` selectors in the active theme's compiled
+ * global-styles CSS so they scope to the editor canvas instead of the
+ * host document's `<html>` element (#679).
+ *
+ * cms-framework's `GlobalStylesEmitter::emit()` follows the WordPress
+ * convention of declaring `--wp--preset--*` tokens *and* theme.json's
+ * root spacing on `:root`. That's correct for the front end and for a
+ * canvas rendered inside a `<BlockCanvas>` iframe, where `:root` is the
+ * iframe's own document. The site editor mounts inline (#418), so the
+ * unmodified output matches the host `<html>` and pushes the whole
+ * editor shell — top bar, navigator, inspector — in by the theme's root
+ * padding.
+ *
+ * Rewriting `:root` to `.editor-styles-wrapper` is a strict narrowing:
+ * the tokens land on the canvas surface element instead of the
+ * document root, every block in the canvas still inherits them, and
+ * theme root spacing applies where a theme author expects it.
+ * Specificity is unchanged — both selectors weigh (0, 1, 0).
+ *
+ * The rewrite deliberately skips `:root` occurrences inside comments,
+ * quoted strings, and unquoted `url()` values, so a `content` string or
+ * an SVG data URI carrying its own `<style>` survives untouched.
+ */
+
+/**
+ * Canvas surface class both site-editor canvases render
+ * ({@see EntityEditorCanvas}, {@see PatternCanvas}). Gutenberg's own
+ * editor styles use the same hook.
+ */
+export const CANVAS_SCOPE_SELECTOR = '.editor-styles-wrapper';
+
+const ROOT_SELECTOR = ':root';
+
+/**
+ * Characters that would make `:root…` a different identifier (there is
+ * no such pseudo-class today, but the guard keeps the rewrite honest if
+ * one ever appears).
+ */
+const IDENT_CHAR = /[A-Za-z0-9_-]/;
+
+/** Opening of a `url()` value, in either case. */
+const URL_FUNCTION = /^url\($/i;
+
+/**
+ * Replaces every `:root` selector in the given CSS with the canvas
+ * scope selector.
+ *
+ * @param css Raw CSS from the global-styles endpoint.
+ *
+ * @return CSS with `:root` rewritten to {@see CANVAS_SCOPE_SELECTOR}.
+ */
+export function scopeGlobalStylesCss(css: string): string {
+    if (css === '') {
+        return css;
+    }
+
+    let out = '';
+    let index = 0;
+
+    while (index < css.length) {
+        const char = css[index];
+
+        // Skip block comments wholesale — `:root` mentioned in the
+        // emitter's own annotations must not be rewritten.
+        if (char === '/' && css[index + 1] === '*') {
+            const end = css.indexOf('*/', index + 2);
+            const stop = -1 === end ? css.length : end + 2;
+            out += css.slice(index, stop);
+            index = stop;
+
+            continue;
+        }
+
+        // Skip quoted strings — `content: ":root"` and `url(":root")`
+        // are values, not selectors.
+        if (char === '"' || char === "'") {
+            const stop = findStringEnd(css, index);
+            out += css.slice(index, stop);
+            index = stop;
+
+            continue;
+        }
+
+        // Skip unquoted `url()` values wholesale. An SVG data URI can
+        // embed its own `<style>` block, and rewriting a selector
+        // inside the image payload would corrupt the asset. Quoted
+        // URLs fall through to the string skipper above, which tracks
+        // escapes and so handles a `)` inside the URL correctly.
+        if (
+            (char === 'u' || char === 'U') &&
+            URL_FUNCTION.test(css.slice(index, index + 4))
+        ) {
+            out += css.slice(index, index + 4);
+            index += 4;
+
+            if (!startsQuotedValue(css, index)) {
+                const end = css.indexOf(')', index);
+                const stop = -1 === end ? css.length : end + 1;
+                out += css.slice(index, stop);
+                index = stop;
+            }
+
+            continue;
+        }
+
+        if (char === ':' && css.startsWith(ROOT_SELECTOR, index)) {
+            const next = css[index + ROOT_SELECTOR.length];
+
+            if (next === undefined || !IDENT_CHAR.test(next)) {
+                out += CANVAS_SCOPE_SELECTOR;
+                index += ROOT_SELECTOR.length;
+
+                continue;
+            }
+        }
+
+        out += char;
+        index += 1;
+    }
+
+    return out;
+}
+
+/**
+ * Reports whether the value starting at `index` (after any leading
+ * whitespace) opens with a quote — i.e. `url( "…" )` rather than
+ * `url(…)`.
+ *
+ * @param css   CSS being scanned.
+ * @param index Index just past the `url(`.
+ *
+ * @return True when the URL is quoted.
+ */
+function startsQuotedValue(css: string, index: number): boolean {
+    let cursor = index;
+
+    while (cursor < css.length && /\s/.test(css[cursor])) {
+        cursor += 1;
+    }
+
+    return css[cursor] === '"' || css[cursor] === "'";
+}
+
+/**
+ * Returns the index just past the closing quote of the string starting
+ * at `start`, honouring backslash escapes. Falls back to the end of the
+ * input for an unterminated string.
+ *
+ * @param css   CSS being scanned.
+ * @param start Index of the opening quote.
+ *
+ * @return Index one past the closing quote.
+ */
+function findStringEnd(css: string, start: number): number {
+    const quote = css[start];
+    let index = start + 1;
+
+    while (index < css.length) {
+        const char = css[index];
+
+        if (char === '\\') {
+            index += 2;
+
+            continue;
+        }
+
+        if (char === quote) {
+            return index + 1;
+        }
+
+        index += 1;
+    }
+
+    return css.length;
+}


### PR DESCRIPTION
## Description

The site-editor's theme global-styles emitter declares theme.json root spacing and the `--wp--preset--*` tokens on `:root`, following the WordPress convention. That's correct for the front end and for a canvas rendered inside a `<BlockCanvas>` iframe — but the site editor mounts **inline** (#418), so `:root` resolves to the host document's `<html>` and the theme's root padding pushes the entire editor shell (top bar, navigator, inspector, canvas) in by that amount. On any host that paints `<body>`, the gap shows up as a visible border around the whole editor.

This PR rewrites `:root` to `.editor-styles-wrapper` before `CanvasThemeStyles` injects the emitter's CSS. The rewrite is a strict narrowing at identical specificity (both selectors weigh 0,1,0): the tokens land on the canvas surface instead of the document root, every block inside still inherits them, and theme root spacing applies where a theme author expects it.

Fixed in the visual-editor rather than in cms-framework's `GlobalStylesEmitter` — the emitter's `:root` output is correct for the front end and for iframed canvases; only the inline site-editor mount needs the narrowing.

**Closes:** #679

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #679

## Motivation and Context

Surfaced while reviewing #677. The dev app added a Tailwind + daisyUI stylesheet to render the media library modal, which gave `<body>` a background and exposed the pre-existing `:root` padding gap. #677 masked it in the dev app; this is the proper fix, and it lets that temporary `html { background: var(--color-base-200) }` mask be removed.

## Changes Made

- Added `resources/js/visual-editor/site-editor/scope-global-styles-css.ts` — `scopeGlobalStylesCss()` rewrites every `:root` selector in the emitter output to `.editor-styles-wrapper`.
- The scanner skips `:root` occurrences inside block comments, quoted strings, and unquoted `url()` values, so a `content` string or an SVG data URI carrying its own `<style>` block survives untouched. Quoted URLs fall through to the string skipper, which tracks escapes and so handles a `)` inside the URL correctly.
- `canvas-theme-styles.tsx` now runs the fetched CSS through that rewrite (memoized on the CSS) before injecting the `<style>` tag.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- Browser (if applicable): Chrome
- PHP Version: 8.4.3
- Project Version: release/1.6 (verified against a host app running v1.5.5 PHP)

**Tests Performed:**
1. Full JS suite — 3142 tests across 335 files, all passing. Full PHP suite — 1730 passed, 1 skipped, 4546 assertions.
2. `tsc --noEmit` reports no errors in the changed files (the repo has pre-existing unrelated type errors elsewhere).
3. Manual verification in a real consumer app (`artisanpack-ui`, which carries **no** temporary mask): built the editor bundle from this branch, swapped it into `public/visual-editor`, opened `/admin/site-editor` and loaded a template part. The injected `ap-canvas-theme-styles` `<style>` tag now reads `.editor-styles-wrapper { padding: … }` with no `:root` rule matching `<html>`; the base-200 border around the shell is gone; theme root spacing still applies inside the canvas and blocks referencing `var(--wp--preset--color--primary)` keep their colors.

**Regression surface checked:** `CanvasThemeStyles` is the only consumer of the global-styles CSS, and both canvases that render it (`EntityEditorCanvas`, `PatternCanvas`) already wrap their content in `.editor-styles-wrapper`, so no out-of-canvas surface loses access to the tokens. The style book renders swatches from resolved API values rather than `var()` references, the styles panels only *produce* `var(--wp--preset--…)` strings as stored attribute values without rendering them as inline styles, and the post editor paints its canvas through the separate `canvas-color-tokens` path. All untouched.

**Security review:** the change is a pure string transform with no new sink — React renders `<style>{css}</style>` as text content, not HTML, exactly as before. The transform can only narrow scope; it never widens or drops rules, and the replacement is a fixed literal, so no attacker-controllable selector can be introduced. The scanner is a single linear pass with no backtracking regex over the input (the only regexes run against a single character or a 4-character slice), so there's no ReDoS surface. Worth stating as a known limitation rather than a regression: this is not a sandbox — theme CSS that already targets `html` or `body` directly still applies, unchanged from before.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [x] Color contrast verified
- [ ] ARIA labels checked

**Details:** No markup, focus order, or ARIA changes — the fix only rescopes a CSS selector. Contrast was confirmed unaffected: theme preset colors still resolve inside the canvas, so block foreground/background pairings render exactly as before.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:**

`__tests__/scope-global-styles-css.test.ts` (11 cases): root padding rewrite; preset tokens staying resolvable; rewrites inside at-rules, selector lists, and descendant selectors; `:root` left alone inside comments, quoted strings, and unquoted data URIs; selectors after a `url()` still rewritten; quoted `url()` containing a `)`; the `:rooted` identifier guard; empty input; unterminated string and unterminated comment.

`__tests__/canvas-theme-styles.test.tsx` (3 cases): the regression assert that the injected `<style>` no longer contains `:root` and carries the canvas-scoped selector instead, plus the two render-nothing states (fetch in flight, empty response).

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Full file-level docblock on the new module explaining why the emitter uses `:root`, why that leaks under inline mounting, and why the rewrite is safe. `canvas-theme-styles.tsx`'s existing docblock gained a paragraph pointing at the rewrite.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated
