### PR TITLE
fix: render core/html block content server-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **`core/html` blocks now render their saved markup** (#690) — the block
+  shipped neither a `block.json` manifest nor a Blade partial, so a
+  `<!-- wp:html -->` block in a theme template or `post_content` fell through
+  to the unknown-block fallback and emitted an empty
+  `data-ve-unknown-block` wrapper with its content dropped. An
+  `artisanpack/html` manifest now declares `content` with `source: "raw"` —
+  activating the matcher `BlockAttributeSourceResolver` already implemented
+  but no bundled manifest used — and the paired `core/html` /
+  `artisanpack/html` partials emit the recovered markup verbatim, with no
+  wrapper element, matching Gutenberg's `<RawHTML>` save. The markup is
+  deliberately not run through `kses()`: the partial sits inside the trust
+  boundary documented on `BlockMarkupHydrator`, and sanitizing here would
+  mangle the `<script>` / `<iframe>` / `<svg>` payloads the block exists to
+  carry. Registration is server-side only — the editor bundle does not yet
+  register a client-side HTML block.
 - **Post-editor canvas now honours the theme's `theme.json` colors** (#695) —
   the canvas body is painted through two package-owned custom properties
   (`--ap-editor-canvas-bg` / `--ap-editor-canvas-fg`) that nothing ever

--- a/packages/visual-editor-renderer-blade/README.md
+++ b/packages/visual-editor-renderer-blade/README.md
@@ -122,6 +122,13 @@ audit ship with a partial, plus the nested sub-blocks (`core/column`,
 - Media: image, gallery, video, audio, file, embed
 - Design: cover, media-text, table, separator, spacer, details, search
 - Layout: columns, column, group, row, stack, buttons, button
+- Widgets: html
+
+`core/html` emits its saved markup verbatim — no wrapper element and no
+sanitization, matching Gutenberg's `<RawHTML>` save. Like every other
+partial's `{!! !!}` output it assumes the block markup is already trusted;
+see the trust-boundary note on `BlockMarkupHydrator` if you render markup
+from an untrusted source.
 
 `core/latest-posts` is intentionally not shipped as a static partial because
 it requires a server query — register it as a `DynamicBlock` in the main

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/html.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/html.blade.php
@@ -1,0 +1,2 @@
+{{-- artisanpack/html — delegates to core/html. --}}
+@include('visual-editor-renderer-blade::blocks.core.html', ['attributes' => $attributes ?? [], 'innerContent' => $innerContent ?? ''])

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/core/html.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/core/html.blade.php
@@ -1,0 +1,28 @@
+{{--
+	core/html — emits the block's saved markup verbatim.
+
+	Matches Gutenberg, whose `core/html` save is a bare `<RawHTML>`: no
+	wrapper element, no `className`/`customClassName` support, nothing
+	added around the author's bytes. A wrapper here would break the one
+	thing the block exists for — pasting markup that has to land exactly
+	as written.
+
+	`content` is recovered by `BlockAttributeSourceResolver`'s `raw`
+	matcher from the block's whole inner HTML (the manifest declares
+	`content` with `source: "raw"`), so it is already the saved markup
+	rather than a text value needing escaping.
+
+	Deliberately NOT run through `kses()`: this partial sits inside the
+	trust boundary documented on `BlockMarkupHydrator` — block markup is
+	only ever rendered from sources the host already trusts (theme files
+	on disk, patterns, editor-authored content that cleared the post
+	editor's authorization). Sanitizing here would silently mangle the
+	valid `<script>`/`<iframe>`/`<svg>` payloads authors reach for this
+	block to write, while doing nothing for a host that is already
+	rendering untrusted markup — that host has to sanitize BEFORE
+	hydrating, as every other block partial's `{!! !!}` assumes.
+--}}
+@php
+	$content = (string) ( $attributes['content'] ?? '' );
+@endphp
+{!! $content !!}

--- a/packages/visual-editor-renderer-blade/tests/Feature/RenderMarkupTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/RenderMarkupTest.php
@@ -53,6 +53,46 @@ it( 'renders core-namespaced theme markup', function () {
 	expect( $html )->toContain( 'HELLO' );
 } )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
+it( 'renders the saved markup of a core/html block verbatim', function () {
+	// #690 — `core/html` keeps everything in its saved HTML and declares
+	// no wrapper supports, so the manifest's `raw` source has to recover
+	// `content` and the partial has to emit it untouched.
+	$html = app( BlockRenderer::class )->renderMarkup(
+		'<!-- wp:html --><div class="x">Raw HTML</div><!-- /wp:html -->'
+	);
+
+	expect( $html )->toContain( '<div class="x">Raw HTML</div>' );
+	expect( $html )->not->toContain( 'data-ve-unknown-block' );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
+
+it( 'renders an artisanpack/html block the same way as its core alias', function () {
+	$html = app( BlockRenderer::class )->renderMarkup(
+		'<!-- wp:artisanpack/html --><p><em>Markup</em> kept as written.</p><!-- /wp:artisanpack/html -->'
+	);
+
+	expect( $html )->toContain( '<p><em>Markup</em> kept as written.</p>' );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
+
+it( 'renders a core/html block from an editor-shape tree', function () {
+	$html = app( BlockRenderer::class )->render( [
+		[
+			'name'        => 'core/html',
+			'attributes'  => [ 'content' => '<span data-x="1">Inline</span>' ],
+			'innerBlocks' => [],
+		],
+	] );
+
+	expect( $html )->toContain( '<span data-x="1">Inline</span>' );
+} );
+
+it( 'renders nothing for a core/html block with no saved content', function () {
+	$html = app( BlockRenderer::class )->render( [
+		[ 'name' => 'core/html', 'attributes' => [], 'innerBlocks' => [] ],
+	] );
+
+	expect( trim( $html ) )->toBe( '' );
+} );
+
 it( 'returns an empty string for blank markup', function () {
 	expect( app( BlockRenderer::class )->renderMarkup( '' ) )->toBe( '' );
 	expect( app( BlockRenderer::class )->renderMarkup( "  \n " ) )->toBe( '' );

--- a/resources/js/visual-editor/blocks/html/block.json
+++ b/resources/js/visual-editor/blocks/html/block.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "artisanpack/html",
+    "title": "Custom HTML",
+    "category": "widgets",
+    "description": "Add custom HTML code and preview it as you edit.",
+    "keywords": [
+        "embed"
+    ],
+    "textdomain": "artisanpack-visual-editor",
+    "attributes": {
+        "content": {
+            "type": "string",
+            "source": "raw"
+        }
+    },
+    "supports": {
+        "customClassName": false,
+        "className": false,
+        "html": false,
+        "interactivity": {
+            "clientNavigation": true
+        }
+    }
+}

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -823,6 +823,11 @@ class VisualEditorServiceProvider extends ServiceProvider
 			'details',
 			// Widgets (I4)
 			'search',
+			// #690 — server-side only for now: the manifest exists so the
+			// hydrator can recover `content` via its `raw` source and the
+			// Blade partial can emit it. There is no `html/index.ts`, so
+			// the editor bundle does not register a client-side block.
+			'html',
 			// Entity (I5)
 			'template-part',
 			'post-title',

--- a/tests/Unit/VisualEditor/Support/BlockMarkupHydratorTest.php
+++ b/tests/Unit/VisualEditor/Support/BlockMarkupHydratorTest.php
@@ -178,13 +178,37 @@ it( 'passes unregistered blocks through with their delimiter attributes intact',
 } )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
 
 it( 'keeps the saved HTML of a block whose content lives only in innerHTML', function () {
-	// `core/html` is the canonical case: no sourced attributes, all of
-	// its content in the saved markup. Dropping innerHTML would lose it
-	// outright.
+	// `core/html` is the canonical case: nothing in the delimiter, all
+	// of its content in the saved markup. Dropping innerHTML would lose
+	// it outright for any caller that reserializes the tree — the
+	// renderer reads the `raw`-sourced `content` attribute instead (see
+	// the next test).
 	$block = $this->hydrator->hydrate( '<!-- wp:html --><div class="x">Raw HTML</div><!-- /wp:html -->' )[0];
 
 	expect( $block['innerHTML'] )->toContain( 'Raw HTML' );
 } )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
+
+it( 'recovers core/html content through the raw source', function () {
+	// #690 — `artisanpack/html` is the only bundled manifest that uses
+	// `source: "raw"`, and the core-namespaced alias has to reach it.
+	$block = $this->hydrator->hydrate( '<!-- wp:html --><div class="x">Raw HTML</div><!-- /wp:html -->' )[0];
+
+	expect( $block['name'] )->toBe( 'core/html' );
+	expect( $block['attributes']['content'] )->toContain( '<div class="x">Raw HTML</div>' );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
+
+it( 'lets a delimiter-persisted content attribute win over the raw recovery', function () {
+	$tree = $this->hydrator->hydrateTree( [
+		[
+			'blockName'   => 'artisanpack/html',
+			'attrs'       => [ 'content' => '<p>from the delimiter</p>' ],
+			'innerBlocks' => [],
+			'innerHTML'   => '<p>stale saved markup</p>',
+		],
+	] );
+
+	expect( $tree[0]['attributes']['content'] )->toBe( '<p>from the delimiter</p>' );
+} );
 
 it( 'omits innerHTML for a self-closing block that saved none', function () {
 	$block = $this->hydrator->hydrate( '<!-- wp:artisanpack/spacer {"height":"40px"} /-->' )[0];


### PR DESCRIPTION
## Description

`core/html` shipped neither a `block.json` manifest nor a Blade partial, so a `<!-- wp:html -->` block in a theme template or `post_content` fell through to `BlockRenderer::renderFallback()` and rendered as an empty `data-ve-unknown-block` wrapper — its content dropped entirely. Since #688 the hydrator preserved the block's `innerHTML` on the tree, so the bytes survived as far as the renderer, but nothing consumed them.

This ships the two missing pieces the issue identified:

1. An `artisanpack/html` manifest declaring `content` with `source: "raw"`. `BlockAttributeSourceResolver` already implemented the `raw` matcher, but no bundled manifest used it, so the path was dead code — no resolver change was needed. The hydrator's `core/` ↔ `artisanpack/` alias fallback means core-namespaced theme markup recovers through it too.
2. Paired `core/html` / `artisanpack/html` Blade partials that emit the recovered markup verbatim.

**Closes:** #690

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #690

## Motivation and Context

Not a regression — `core/html` never rendered server-side. #688 made the gap reachable and visible. Any block theme or post using a Custom HTML block silently loses that content on the front end.

### Trust-boundary decision

The issue asked for an explicit call on whether the partial passes HTML through verbatim (matching WP) or runs it through `kses()` from `artisanpack-ui/security`. **This PR passes it through verbatim**, for three reasons, documented in the partial's docblock:

- The partial sits inside the trust boundary already documented on `BlockMarkupHydrator`: block markup is only rendered from sources the host already trusts (theme files on disk, patterns, editor-authored content that cleared the post editor's authorization).
- Every other block partial's `{!! !!}` output makes the same assumption — sanitizing only this one would be inconsistent without closing anything.
- `core/html` is the one block whose entire purpose is arbitrary markup; `kses()` would mangle the `<script>` / `<iframe>` / `<svg>` payloads authors reach for it to write.

A host rendering genuinely untrusted markup has to sanitize *before* hydrating regardless — that is unchanged by this PR.

Security review confirmed no new attack surface: the only callers of the hydrator are `TemplatePartInliner` (theme files on disk) and `BlockRenderer::renderMarkup()` (host-invoked). `BlockPreviewController` is the one request-reachable render path and it resolves *dynamic* blocks only — `artisanpack/html` is static, so it 404s there. Comment bodies reach `artisanpack/comment-content` as a pre-resolved attribute string and are never parsed as block markup.

## Changes Made

- Added `resources/js/visual-editor/blocks/html/block.json` — `artisanpack/html`, mirroring upstream `core/html` (`content` with `source: "raw"`, `className`/`customClassName`/`html` supports off).
- Registered `html` in `VisualEditorServiceProvider::registerForkedBlocks()`.
- Added `blocks/core/html.blade.php` — emits `{!! $content !!}` with no wrapper element, matching Gutenberg's `<RawHTML>` save.
- Added `blocks/artisanpack/html.blade.php` — delegates to the core partial, matching the existing `code` / `preformatted` convention.
- Documented the block and its trust boundary in the renderer package README, plus a CHANGELOG entry.

### Deliberately out of scope

- **No client-side block.** There is no `html/index.ts`, so the editor bundle does not register an HTML block. The issue is scoped to server-side rendering; an editor UI (the Custom HTML block's edit/preview toggle) is separate work.
- **React/Vue renderers unchanged.** `visual-editor-renderer-react` and `-vue` have no `core/html` component either, so they still fall through to `unknownBlock`. Same defect, different surface, and it needs its own `dangerouslySetInnerHTML` trust decision — worth a follow-up issue.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- Browser (if applicable): n/a — server-side rendering
- PHP Version: 8.4.3
- Project Version: 1.5.5 (branched off `release/1.6`)

**Tests Performed:**
1. Ran the issue's exact repro through the symlinked dev app: `app( BlockRenderer::class )->renderMarkup( '<!-- wp:html --><div class="x">Raw HTML</div><!-- /wp:html -->' )` now returns `<div class="x">Raw HTML</div>` instead of the empty `data-ve-unknown-block` wrapper.
2. Full PHP suite: **1736 passed, 1 skipped** (4556 assertions).
3. JS editor + site-editor vitest suites: **342 passed** across 31 files (no client-side change, run to confirm the manifest-without-`index.ts` directory does not disturb the `import.meta.glob` discovery).

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — this is a server-side rendering fix with no UI surface of its own. The change makes author-written markup reach the page instead of being silently dropped; the accessibility of that markup is the author's, and passing it through verbatim (rather than sanitizing) preserves any ARIA attributes and semantic elements they wrote, which a `kses()` pass could have stripped.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

`tests/Unit/VisualEditor/Support/BlockMarkupHydratorTest.php`
- *recovers core/html content through the raw source* — the core-namespaced alias reaches the `artisanpack/html` manifest and populates `content`.
- *lets a delimiter-persisted content attribute win over the raw recovery* — guards the hydrator's "recovery fills gaps, never blanks" layering for the new `raw` path.
- Updated the stale comment on the existing *keeps the saved HTML…* test, which described `core/html` as having no sourced attributes — no longer true.

`packages/visual-editor-renderer-blade/tests/Feature/RenderMarkupTest.php`
- *renders the saved markup of a core/html block verbatim* — the issue's repro, asserting `data-ve-unknown-block` is gone.
- *renders an artisanpack/html block the same way as its core alias*.
- *renders a core/html block from an editor-shape tree* — the non-hydrator path.
- *renders nothing for a core/html block with no saved content*.

## Documentation

- [x] Inline code documentation added
- [x] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** The `core/html` partial carries a docblock explaining both the no-wrapper choice and the deliberate absence of `kses()`. The renderer package README lists the block under a new "Widgets" line with the same note. CHANGELOG entry added under Unreleased → Fixed.

## Screenshots

n/a — server-side rendering change.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [ ] Code has been linted — this package ships no lint tooling (`composer.json` has only a `test` script); style matched to the surrounding files by hand
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated
