### PR TITLE
fix: register artisanpack/marquee so its sourced attributes recover

### DIFF
--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -878,6 +878,13 @@ class VisualEditorServiceProvider extends ServiceProvider
 		$referenceBlocks = [
 			'callout',
 			'icon',
+			// #691 — `marquee` declares a sourced attribute
+			// (`marqueeContent`, `source: html`), so it has to be in the
+			// server-side registry for BlockMarkupHydrator to recover the
+			// text out of saved markup. Without it the Blade partial
+			// renders an empty marquee. See the guard test in
+			// tests/Unit/VisualEditor/SourcedBlocksAreRegisteredTest.php.
+			'marquee',
 		];
 
 		foreach ( $referenceBlocks as $block ) {

--- a/tests/Unit/VisualEditor/SourcedBlocksAreRegisteredTest.php
+++ b/tests/Unit/VisualEditor/SourcedBlocksAreRegisteredTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditor\Registries\BlockTypeRegistry;
+
+/**
+ * #691 — `BlockMarkupHydrator::recoverAttributes()` looks a block up in the
+ * `BlockTypeRegistry` before it can replay the manifest's `source`
+ * definitions against the saved markup. A manifest that declares a sourced
+ * attribute but never reaches the registry silently loses that attribute:
+ * `artisanpack/marquee` shipped that way and rendered an empty marquee.
+ *
+ * This guard walks every bundled manifest and fails the moment a new sourced
+ * block is added without a matching entry in
+ * `VisualEditorServiceProvider::registerForkedBlocks()` or
+ * `registerReferenceBlocks()`.
+ *
+ * Note that a manifest registered behind a soft-dependency gate (`form`
+ * behind artisanpack-ui/forms, `latest-posts` behind cms-framework) would
+ * fail this guard if it ever grew a sourced attribute — correctly so, since
+ * the attribute genuinely would not recover in an install lacking that
+ * package. None of them declare one today.
+ */
+it( 'registers every bundled block that declares a sourced attribute', function () {
+	$blocksDir = __DIR__ . '/../../../resources/js/visual-editor/blocks';
+	$manifests = glob( $blocksDir . '/*/block.json' ) ?: [];
+
+	expect( $manifests )->not->toBeEmpty();
+
+	$registry = app( BlockTypeRegistry::class );
+	$missing  = [];
+
+	foreach ( $manifests as $manifest ) {
+		$metadata = json_decode( (string) file_get_contents( $manifest ), true, 512, JSON_THROW_ON_ERROR );
+
+		$attributes = $metadata['attributes'] ?? [];
+
+		if ( ! is_array( $attributes ) ) {
+			continue;
+		}
+
+		$hasSourcedAttribute = false;
+
+		foreach ( $attributes as $attribute ) {
+			if ( is_array( $attribute ) && isset( $attribute['source'] ) ) {
+				$hasSourcedAttribute = true;
+
+				break;
+			}
+		}
+
+		if ( ! $hasSourcedAttribute ) {
+			continue;
+		}
+
+		$name = $metadata['name'] ?? '';
+
+		if ( null === $registry->get( (string) $name ) ) {
+			$missing[] = $name;
+		}
+	}
+
+	expect( $missing )->toBe(
+		[],
+		'Blocks declaring a sourced attribute must be registered in VisualEditorServiceProvider: ' . implode( ', ', $missing )
+	);
+} );
+
+it( 'registers the marquee block from its bundled manifest', function () {
+	$block = app( BlockTypeRegistry::class )->get( 'artisanpack/marquee' );
+
+	expect( $block )->not->toBeNull()
+		->and( $block['title'] )->toBe( 'Marquee' )
+		->and( $block['attributes']['marqueeContent']['source'] )->toBe( 'html' );
+} );

--- a/tests/Unit/VisualEditor/Support/BlockMarkupHydratorTest.php
+++ b/tests/Unit/VisualEditor/Support/BlockMarkupHydratorTest.php
@@ -274,6 +274,17 @@ it( 'truncates a pathologically deep tree instead of exhausting the stack', func
 	expect( $depth )->toBeLessThan( BlockMarkupHydrator::MAX_DEPTH );
 } );
 
+it( 'recovers marquee content from saved markup', function () {
+	$markup = '<!-- wp:artisanpack/marquee -->'
+		. '<div class="wp-block-marquee"><p>Scrolling text</p></div>'
+		. '<!-- /wp:artisanpack/marquee -->';
+
+	$block = $this->hydrator->hydrate( $markup )[0];
+
+	expect( $block['name'] )->toBe( 'artisanpack/marquee' )
+		->and( $block['attributes']['marqueeContent'] )->toBe( 'Scrolling text' );
+} )->skip( fn () => ! BlockMarkupHydrator::canParseMarkup(), 'requires cms-framework 2.5+ (PHP 8.3+) for BlockMarkupParser' );
+
 it( 'recovers nothing when the block type declares no sourced attributes', function () {
 	app( BlockTypeRegistry::class )->register( 'acme/plain', [
 		'attributes' => [ 'label' => [ 'type' => 'string' ] ],


### PR DESCRIPTION
## Description

`artisanpack/marquee` was the only one of the 105 bundled `block.json` manifests that declares a `source` definition while being absent from both registration lists in `VisualEditorServiceProvider` (`$forkedBlocks` and `$referenceBlocks`).

`BlockMarkupHydrator::recoverAttributes()` looks the block up in `BlockTypeRegistry`; finding nothing, it returned `[]`, so `marqueeContent` was never recovered from saved markup and `marquee.blade.php` rendered an empty marquee.

**Closes:** #691

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #691

## Motivation and Context

Pre-existing bug, surfaced during review of #689 which audited all 105 manifests against the registry and found this the single mismatch. Any author who used the Marquee block lost their text on save/reload and got empty markup on the front end.

### On the issue's "better fix" (glob the blocks directory)

Deliberately **not** done. The two arrays are not merely a drifting duplicate of the directory listing: ~55 of the 108 manifests are intentionally not registered by those methods, and several register elsewhere behind soft-dependency gates — `form` behind `artisanpack-ui/forms`, `latest-posts` and the taxonomy blocks behind cms-framework's `BlogManager`. A blanket glob would register all of them unconditionally, changing `getEnabledBlockNames()` and the inserter contents well beyond this bug.

The guard test gives the drift protection the issue asks for without that blast radius. Encoding the forked/reference distinction as a manifest field and driving registration from the manifests is worth doing, but as its own issue.

## Changes Made

- Added `'marquee'` to `$referenceBlocks` in `VisualEditorServiceProvider::registerReferenceBlocks()`, with a comment pointing at the guard test.
- New `tests/Unit/VisualEditor/SourcedBlocksAreRegisteredTest.php` — globs all bundled manifests, collects every one declaring a `source` on any attribute, and asserts each is present in `BlockTypeRegistry`. Failure message names the offending blocks.
- New regression test in `BlockMarkupHydratorTest` hydrating the exact markup from the issue's repro.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser (if applicable): n/a (server-side)
- PHP Version: 8.4
- Project Version: 1.5.5 (branch `release/1.6`)

**Tests Performed:**
1. Full Pest suite: **1739 passed, 1 skipped** (4565 assertions).
2. Verified the guard test genuinely fails without the fix — stashing the provider change produces `Blocks declaring a sourced attribute must be registered in VisualEditorServiceProvider: artisanpack/marquee`. It is not a vacuous assertion.
3. Manual verification in the dev app: saved a page with a Marquee block, reloaded the editor (text recovers), and viewed the front end (marquee renders its text instead of empty markup).

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — server-side block-registration fix with no UI surface of its own. The change does restore visible marquee text that was previously rendering empty, which is a net accessibility improvement (the block's `ariaLabel`/`anchor` supports are unchanged).

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** One guard test file (2 tests) plus one hydrator regression test. The guard is the durable piece — it catches the next manifest that ships a sourced attribute without registration.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Docblock on the new test file explains why the guard exists and notes that a soft-dependency-gated manifest growing a sourced attribute would correctly fail it. Inline comment on the `$referenceBlocks` entry explains why `marquee` must be registered.

## Security Review

Reviewed; no new exposure. The provider change appends a literal string to a hardcoded array and loads a package-local `block.json` behind a `file_exists()` guard — no user input reaches the path. The new tests read only package files.

Worth flagging for the reviewer, since the fix does newly put author-authored HTML on a render path: `marquee.blade.php` emits `{!! $content !!}`, matching `paragraph.blade.php` and the other rich-text partials. The trust boundary (authenticated block authors) and escaping convention are unchanged relative to sibling blocks — this PR does not introduce a divergence, it just makes marquee behave like every other sourced block. If that convention is ever revisited, it should be revisited for all rich-text partials at once.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Marquee block content is now correctly registered for server-side hydration, helping preserve sourced content when rendering saved markup.

* **Tests**
  * Added coverage to verify sourced blocks are registered, including the marquee block and its content attribute.
  * Added an integration test covering recovery of marquee content from saved markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->