### PR TITLE
fix: resolve container bindings without a leading backslash

### DIFF
--- a/src/Blocks/DynamicContent/DynamicLoopBlock.php
+++ b/src/Blocks/DynamicContent/DynamicLoopBlock.php
@@ -88,7 +88,7 @@ class DynamicLoopBlock extends DynamicBlock implements WantsInnerBlocks
 			return '<div class="ve-dynamic-loop-empty" role="note">No records to display.</div>';
 		}
 
-		$rendererClass = '\\ArtisanPackUI\\VisualEditorRendererBlade\\BlockRenderer';
+		$rendererClass = 'ArtisanPackUI\\VisualEditorRendererBlade\\BlockRenderer';
 
 		if ( ! class_exists( $rendererClass ) ) {
 			return '';

--- a/src/Blocks/DynamicContent/SnippetBlock.php
+++ b/src/Blocks/DynamicContent/SnippetBlock.php
@@ -91,7 +91,7 @@ class SnippetBlock extends DynamicBlock
 	 */
 	protected function renderTree( array $blocks, string $ownerSlug ): string
 	{
-		$rendererClass = '\\ArtisanPackUI\\VisualEditorRendererBlade\\BlockRenderer';
+		$rendererClass = 'ArtisanPackUI\\VisualEditorRendererBlade\\BlockRenderer';
 
 		if ( ! class_exists( $rendererClass ) ) {
 			return '';

--- a/src/Http/Controllers/EntitySearchController.php
+++ b/src/Http/Controllers/EntitySearchController.php
@@ -89,9 +89,12 @@ class EntitySearchController extends Controller
 	 */
 	protected function searchCmsFrameworkEntities( string $type, string $needle ): array
 	{
+		// No leading backslash: the container does not normalise FQCN
+		// keys, so `'\Foo\Bar'` would miss a binding registered under
+		// `Foo\Bar::class` and silently build a fresh resolver instead.
 		$resolverClass = 'template' === $type
-			? '\\ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Resolution\\TemplateResolver'
-			: '\\ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Resolution\\TemplatePartResolver';
+			? 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Resolution\\TemplateResolver'
+			: 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Resolution\\TemplatePartResolver';
 
 		if ( ! class_exists( $resolverClass ) ) {
 			return [];

--- a/src/Http/Controllers/MenuLocationsController.php
+++ b/src/Http/Controllers/MenuLocationsController.php
@@ -72,8 +72,8 @@ class MenuLocationsController extends Controller
 			return response()->json( [ 'data' => [] ] );
 		}
 
-		$themeManagerClass    = '\\ArtisanPackUI\\CMSFramework\\Modules\\Themes\\Managers\\ThemeManager';
-		$assignmentClass      = '\\ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Models\\MenuLocationAssignment';
+		$themeManagerClass    = 'ArtisanPackUI\\CMSFramework\\Modules\\Themes\\Managers\\ThemeManager';
+		$assignmentClass      = 'ArtisanPackUI\\CMSFramework\\Modules\\SiteEditor\\Models\\MenuLocationAssignment';
 		$themeManager         = app( $themeManagerClass );
 		$activeTheme          = $themeManager->getActiveTheme();
 		$activeSlug           = is_array( $activeTheme ) && ! empty( $activeTheme['slug'] ) ? (string) $activeTheme['slug'] : null;

--- a/src/Visibility/VisibilityEvaluator.php
+++ b/src/Visibility/VisibilityEvaluator.php
@@ -309,7 +309,7 @@ class VisibilityEvaluator
 	 */
 	protected function resolveRoles( object $user ): array
 	{
-		$manager = '\\ArtisanPackUI\\CMSFramework\\Modules\\Users\\Managers\\RoleManager';
+		$manager = 'ArtisanPackUI\\CMSFramework\\Modules\\Users\\Managers\\RoleManager';
 
 		if ( class_exists( $manager ) ) {
 			try {

--- a/src/VisualEditorServiceProvider.php
+++ b/src/VisualEditorServiceProvider.php
@@ -576,7 +576,7 @@ class VisualEditorServiceProvider extends ServiceProvider
 	 */
 	protected function registerQueryResolverBinding(): void
 	{
-		$cmsRuntime = '\\ArtisanPackUI\\CMSFramework\\Modules\\Blog\\Services\\QueryRuntime';
+		$cmsRuntime = 'ArtisanPackUI\\CMSFramework\\Modules\\Blog\\Services\\QueryRuntime';
 
 		if ( ! class_exists( $cmsRuntime ) ) {
 			return;

--- a/tests/Feature/VisualEditor/EntitySearchControllerTest.php
+++ b/tests/Feature/VisualEditor/EntitySearchControllerTest.php
@@ -2,20 +2,51 @@
 
 declare( strict_types=1 );
 
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\ResolvedEntity;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplatePartResolver;
+use ArtisanPackUI\CMSFramework\Modules\SiteEditor\Resolution\TemplateResolver;
 use Tests\TestUser;
 
 /*
  * Template + template-part searches reach cms-framework's
  * `TemplateResolver` / `TemplatePartResolver` (see
- * `src/Http/Controllers/EntitySearchController.php`). The resolvers
- * aren't bound in this Testbench environment, so the template /
- * template-part branches return empty data — the consuming app's test
- * suite covers the populated path.
+ * `src/Http/Controllers/EntitySearchController.php`). No theme is
+ * active in this Testbench environment, so the real resolvers return
+ * nothing and the template / template-part branches come back empty —
+ * the consuming app's test suite covers the populated path. The
+ * override tests below bind stand-in resolvers to prove the controller
+ * resolves them through the container.
  *
  * Resource-config sources (pages, posts, etc.) are still testable
  * here because they go through Eloquent directly via the
  * `artisanpack.visual-editor.resources` map.
  */
+
+/**
+ * Builds the `ResolvedEntity` rows a stand-in resolver hands back.
+ * `area` is null for templates and the part's own area for parts,
+ * matching what cms-framework's resolvers emit.
+ *
+ * @param  list<array{slug: string, title: string, area?: string}>  $rows
+ * @return list<ResolvedEntity>
+ */
+function entitySearchStubEntities( array $rows ): array
+{
+	return array_map( static fn ( array $row ): ResolvedEntity => new ResolvedEntity(
+		slug: $row['slug'],
+		theme: 'artisanpack-ui',
+		source: 'theme',
+		raw: '',
+		blocks: [],
+		title: $row['title'],
+		description: '',
+		status: 'publish',
+		hasThemeFile: true,
+		isCustom: false,
+		area: $row['area'] ?? null,
+		model: null,
+	), $rows );
+}
 
 function actingAsSearchUser(): TestUser
 {
@@ -46,7 +77,7 @@ it( 'returns an empty data array for an unknown type slug', function () {
 		->assertJsonPath( 'data', [] );
 } );
 
-it( 'returns an empty data array for template type when cms-framework is not installed', function () {
+it( 'returns an empty data array for template type when no theme resolves', function () {
 	actingAsSearchUser();
 
 	$this->getJson( '/visual-editor/api/search?type=template' )
@@ -54,10 +85,67 @@ it( 'returns an empty data array for template type when cms-framework is not ins
 		->assertJsonPath( 'data', [] );
 } );
 
-it( 'returns an empty data array for template-part type when cms-framework is not installed', function () {
+it( 'returns an empty data array for template-part type when no theme resolves', function () {
 	actingAsSearchUser();
 
 	$this->getJson( '/visual-editor/api/search?type=template-part' )
 		->assertOk()
 		->assertJsonPath( 'data', [] );
+} );
+
+/*
+ * #692 — the controller used to build the resolver FQCN with a leading
+ * backslash. Laravel's container doesn't normalise that, so a binding
+ * registered under `TemplateResolver::class` was skipped and a fresh
+ * resolver was constructed instead. These two tests fail against the
+ * old string and pass against the canonical key.
+ */
+
+it( 'resolves the template resolver through the container so hosts can override it', function () {
+	actingAsSearchUser();
+
+	app()->instance( TemplateResolver::class, new class extends TemplateResolver
+	{
+		public function __construct()
+		{
+		}
+
+		public function all(): array
+		{
+			return entitySearchStubEntities( [
+				[ 'slug' => 'single', 'title' => 'Single Post' ],
+				[ 'slug' => 'archive', 'title' => 'Archive' ],
+			] );
+		}
+	} );
+
+	$this->getJson( '/visual-editor/api/search?type=template' )
+		->assertOk()
+		->assertJsonPath( 'data.0', [ 'type' => 'template', 'id' => 'archive', 'title' => 'Archive', 'url' => null ] )
+		->assertJsonPath( 'data.1', [ 'type' => 'template', 'id' => 'single', 'title' => 'Single Post', 'url' => null ] );
+} );
+
+it( 'resolves the template-part resolver through the container so hosts can override it', function () {
+	actingAsSearchUser();
+
+	app()->instance( TemplatePartResolver::class, new class extends TemplatePartResolver
+	{
+		public function __construct()
+		{
+		}
+
+		public function all(): array
+		{
+			return entitySearchStubEntities( [
+				[ 'slug' => 'header', 'title' => 'Header', 'area' => 'header' ],
+				[ 'slug' => 'footer', 'title' => 'Footer', 'area' => 'footer' ],
+			] );
+		}
+	} );
+
+	$this->getJson( '/visual-editor/api/search?type=template-part&q=head' )
+		->assertOk()
+		->assertJsonPath( 'data', [
+			[ 'type' => 'template-part', 'id' => 'header', 'title' => 'Header', 'url' => null ],
+		] );
 } );


### PR DESCRIPTION
## Description

Laravel's container does not normalise FQCN keys, so `'\Foo\Bar'` and `Foo\Bar::class` are two distinct entries. `EntitySearchController::searchCmsFrameworkEntities()` built the template / template-part resolver class strings **with** a leading backslash, so `app( $resolverClass )` missed any host- or test-registered binding and silently constructed a fresh resolver instead. `class_exists()` behaves identically either way, which is why the guard above it hid the problem — the code "worked", just never with the override the host asked for.

This drops the leading backslash there, and sweeps the rest of the package for the same pattern.

**Closes:** #692

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #692

## Motivation and Context

Host apps and test suites can't decorate or stub the site-editor resolvers behind the entity-search endpoint — their binding is registered under the canonical key and the controller looks up a different one. The failure is silent: results still come back, just from the wrong (freshly-constructed) instance.

Pre-existing; **not** introduced by #688. Found during review of #689 while fixing the identical bug in `TemplatePartInliner` — that one surfaced only because a new test tried to inject a stub resolver and quietly got the real one instead. It was left out of #689 to keep that diff scoped.

## Changes Made

- `EntitySearchController` — dropped the leading `\` from both resolver class strings, with a comment explaining why the canonical key matters.
- Swept the package for the same pattern and corrected every site whose class string is **resolved through the container**:
  - `VisualEditorServiceProvider::registerQueryResolverBinding()` — `QueryRuntime` (via `$app->make()`)
  - `SnippetBlock::renderTree()` — `BlockRenderer`
  - `DynamicLoopBlock` — `BlockRenderer`
  - `VisibilityEvaluator::resolveRoles()` — `RoleManager`
  - `MenuLocationsController` — `ThemeManager` (plus the sibling `MenuLocationAssignment` string in the same statement, for consistency)
- Deliberately **left alone** the sites whose class strings only feed `class_exists()` or static Eloquent calls, where the leading backslash is inert: `PatternInliner::PATTERN_MODEL`, `CustomFieldSource`'s `$cmsField`, and `MenuLocationsController::cmsFrameworkAvailable()`. Changing those would widen the diff without fixing anything.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- Browser (if applicable): n/a — server-side
- PHP Version: 8.4.3
- Project Version: 1.5.5 (branched off `release/1.6`)

**Tests Performed:**
1. Full package suite: `composer test` — 1741 passed, 1 skipped, 4570 assertions.
2. Verified the new tests are genuine regression guards: temporarily restored the leading backslash in `EntitySearchController` and confirmed the template override test fails, then confirmed it passes with the fix.
3. Manual verification in the dev app — the link-control menu picker still populates Template / Template Part results against a real cms-framework install; smoke-checked the dynamic loop / snippet block rendering and the menu-locations endpoint, since those share the fix.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — this is a server-side container-resolution fix with no rendered output or markup changes. The picker's UI is unchanged.

## Tests Added

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** Two regression tests in `tests/Feature/VisualEditor/EntitySearchControllerTest.php` bind stand-in `TemplateResolver` / `TemplatePartResolver` instances under the canonical key and assert the controller uses them. The template test also pins the alphabetical sort; the template-part test exercises the `q=` needle filter. Both fail against the old string.

The two pre-existing "cms-framework is not installed" tests were renamed to "when no theme resolves" — cms-framework *is* present in the Testbench environment, so the empty result comes from there being no active theme, not from a missing package. The file's header comment was corrected to match.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Added an inline comment at the fix site explaining the container's lack of FQCN normalisation, so the missing backslash reads as deliberate rather than as a typo waiting to be "fixed" back. No public API changed, so no README/wiki updates are needed.

## Screenshots

n/a — no visual change.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [ ] Code has been linted — this package ships no lint tooling (`composer.json` has only a `test` script); style was matched by hand against the surrounding code.
- [x] Accessibility tests completed — n/a, see above
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated
