### PR TITLE
test: add a Blade-vs-JS markup parity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **Blade-vs-JS markup parity check** (#704) — nothing guarded against the three
+  renderers drifting on markup: `scripts/verify-renderer-parity.mjs` compares
+  block *names* only, and `parity.test.ts` compares React against Vue with Blade
+  left out of both. That is why the Blade-only #700 fix could land green while
+  making Blade disagree with the JS renderers, undetected until #702. A shared
+  fixture set (`packages/renderer-markup-parity/fixtures.json`) is now rendered
+  through all three renderers: the Pest suite writes canonicalized golden files
+  from `<x-ve-blocks>`, and the vitest suite asserts the React and Vue SSR output
+  matches them, so drift in any renderer fails CI at the point it is introduced.
+  Fixtures cover every layout-supporting wrapper — `group` (flow / constrained /
+  flex / grid), `row`, `stack`, `columns`, `buttons`, `post-content` with and
+  without a stored layout, and `post-template` (list / grid / masonry).
+  Canonicalization is narrow and documented: whitespace, attribute order and CSS
+  declaration separators are normalized; element names, class tokens and
+  attribute values are not. Known divergences are declared explicitly in the
+  fixture manifest with a tracking issue rather than papered over with loose
+  matching.
+
 ### Fixed
 
 - **`core/html` blocks now render their saved markup** (#690) — the block

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,8 @@
     "repositories": "The path repository to ../cms-framework is a development-only convenience for the symlinked workflow used in the dev-app (see ../artisanpack-ui-dev/composer.json). On a fresh clone without the sibling cms-framework checkout, composer install will fail to resolve cms-framework — that's expected for now; the package's release pipeline pulls cms-framework from Packagist via the ^2.0 constraint. CI removes this entry before installing. Tracked for a permanent fix (e.g. an env-gated repository) in #434."
   },
   "scripts": {
-    "test": "./vendor/bin/pest"
+    "test": "./vendor/bin/pest",
+    "test:update-markup-goldens": "UPDATE_MARKUP_GOLDENS=1 ./vendor/bin/pest --no-coverage packages/visual-editor-renderer-blade/tests/Feature/RendererMarkupParityTest.php"
   },
   "config": {
     "allow-plugins": {

--- a/packages/renderer-markup-parity/README.md
+++ b/packages/renderer-markup-parity/README.md
@@ -1,0 +1,114 @@
+# Renderer markup parity (#704)
+
+The Blade, React and Vue renderers are meant to be interchangeable: the
+same block tree must produce the same markup through any of them. Two
+checks already guard part of that contract —
+`scripts/verify-renderer-parity.mjs` (same block *names* registered
+everywhere) and `packages/visual-editor-renderer-vue/tests/parity.test.ts`
+(byte-identical HTML between **React and Vue**). Neither compares Blade's
+markup against the JS renderers', which is how #700 could land a
+Blade-only fix that silently made Blade disagree with both JS renderers
+until #702 was filed.
+
+This directory closes that gap.
+
+## How it works
+
+- **`fixtures.json`** is the single, language-neutral source of truth: a
+  list of block trees, plus the manifest of known renderer divergences. A
+  fixture added here is automatically exercised against all three
+  renderers.
+- **The Blade suite writes the goldens.**
+  `packages/visual-editor-renderer-blade/tests/Feature/RendererMarkupParityTest.php`
+  renders each fixture through `<x-ve-blocks>`, canonicalizes it, and
+  compares it against `goldens/<name>.txt`.
+- **The JS suite reads them.** `tests/blade-parity.test.ts` renders each
+  fixture through the React and Vue SSR entry points, canonicalizes with
+  the same algorithm, and asserts the result equals the golden.
+
+So a divergence introduced in Blade fails the Pest suite (golden
+mismatch), and one introduced in React or Vue fails the vitest suite.
+Both suites already run in CI on every PR (`test-php` and `test-js` in
+`.github/workflows/ci.yml`), so no separate job is needed.
+
+## Regenerating the goldens
+
+Only when the markup change is intentional, and only after reviewing the
+diff — a golden update is the reviewable record that the contract moved:
+
+```bash
+composer test:update-markup-goldens
+```
+
+Then re-run the JS side to confirm React and Vue agree with the new
+markup:
+
+```bash
+npm test -- packages/renderer-markup-parity
+```
+
+## Canonicalization contract
+
+`canonicalize.ts` and its PHP twin
+(`packages/visual-editor-renderer-blade/tests/Support/CanonicalMarkup.php`)
+implement the same algorithm. Keep them in sync — if they drift, the two
+suites stop agreeing about what the goldens mean.
+
+Normalized (insignificant across renderers):
+
+- **Whitespace.** Runs collapse to a single space; whitespace-only text
+  nodes are dropped; the leading/trailing space of an element's first and
+  last text child is trimmed.
+- **Attribute order.** Attributes are sorted by name.
+- **`class` whitespace.** Collapsed and trimmed — token spelling and
+  order are preserved exactly.
+- **`style` separators.** Each declaration is trimmed and re-joined with
+  `; `, and the whitespace around the property/value `:` is normalized —
+  Vue's server renderer emits a trailing `;` and React writes
+  `flex-basis:60%` where Blade writes `flex-basis: 60%`. Property names,
+  values and declaration order are preserved exactly.
+- **Comments.** Dropped, which also removes Vue's SSR fragment markers.
+
+Not normalized: element names, class tokens, attribute names, attribute
+values.
+
+## Scope: markup, not CSS
+
+The check compares block markup only. Renderer-injected
+`<style data-ve-*>` blocks are stripped from both sides, because the
+layout baseline CSS is a *known intentional* divergence: the JS
+renderers' `LAYOUT_BASELINE_CSS` carries three constrained-group
+containment rules that the Blade baseline does not, since Blade emits
+them from `ThemeJsonTokensCompiler::compileLayoutRules()` gated on the
+`theme.json` layout sizes (see the header comment in
+`layoutBaselineCss.ts`). Comparing the CSS here would only encode that
+difference a second time.
+
+## Known divergences
+
+### Encoded in `fixtures.json`
+
+`knownDivergences` declares class tokens that one renderer emits and the
+others do not, with the reason and the tracking issue. Matching tokens
+are dropped from every class attribute on both sides before comparison —
+narrow and explicit, rather than loosening the match. Currently:
+
+- **`ve-w-<hash>` (#712, introduced by #487).** `core/column`'s Blade partial mints a hashed
+  scope class and pushes matching `flex-basis` / `flex-grow`
+  `!important` rules into the per-request responsive accumulator, so an
+  explicit column width survives WP core's mobile stacking rule. React
+  and Vue emit the inline `flex-basis` only. Dropping the token keeps the
+  rest of the column markup — including the inline style — under
+  comparison instead of dropping the width fixture entirely.
+
+### Not covered by a fixture
+
+- **`group` with the #595 Flex Layout panel active at the base
+  breakpoint.** `group.blade.php` flips its layout class to
+  `is-layout-flex` when `artisanpackFlex` emits the unprefixed `ap-flex`
+  class; React's `GroupBlock` and its Vue twin have no equivalent, so the
+  same tree renders `is-layout-flow` there. This is a genuine
+  pre-existing divergence rather than an intentional one, so it is
+  deliberately *not* normalized away here — it needs a fix in one of the
+  renderers, tracked in #711. Add a fixture for it once the renderers
+  agree.

--- a/packages/renderer-markup-parity/canonicalize.ts
+++ b/packages/renderer-markup-parity/canonicalize.ts
@@ -33,19 +33,6 @@ const VOID_ELEMENTS = new Set([
 ]);
 
 /**
- * Strips the renderer-injected `<style data-ve-*>` blocks.
- *
- * This check covers block markup only. The layout baseline / global-styles
- * CSS is a known, documented divergence between Blade (which emits it from
- * `ThemeJsonTokensCompiler::compileLayoutRules()`, gated on theme.json
- * layout sizes) and the JS renderers (which ship `LAYOUT_BASELINE_CSS`), so
- * comparing it here would only encode that difference twice.
- */
-export function stripRendererStyleTags(html: string): string {
-    return html.replace(/<style\s+data-ve-[^>]*>[\s\S]*?<\/style>/g, '');
-}
-
-/**
  * Class-token regexes declared as known renderer divergences.
  */
 let dropClassPatterns: RegExp[] = [];
@@ -66,7 +53,7 @@ export function canonicalizeHtml(
 
     const root = document.createElement('div');
 
-    root.innerHTML = stripRendererStyleTags(html);
+    root.innerHTML = html;
 
     const lines: string[] = [];
 

--- a/packages/renderer-markup-parity/canonicalize.ts
+++ b/packages/renderer-markup-parity/canonicalize.ts
@@ -1,0 +1,211 @@
+/**
+ * Canonical markup serializer for the Blade-vs-JS parity check (#704).
+ *
+ * Parses rendered HTML and re-emits it as an indented, deterministic tree
+ * so the React / Vue renderers' output can be compared against the golden
+ * files the Blade suite writes, without tripping over incidental
+ * formatting differences between the three renderers.
+ *
+ * Normalization is deliberately narrow — see README.md. In short:
+ * whitespace and attribute order are normalized; element names, class
+ * tokens and attribute values are not.
+ *
+ * The PHP twin of this module lives at
+ * packages/visual-editor-renderer-blade/tests/Support/CanonicalMarkup.php.
+ * Any change here must be mirrored there or the two suites stop agreeing.
+ */
+
+const VOID_ELEMENTS = new Set([
+    'area',
+    'base',
+    'br',
+    'col',
+    'embed',
+    'hr',
+    'img',
+    'input',
+    'link',
+    'meta',
+    'param',
+    'source',
+    'track',
+    'wbr',
+]);
+
+/**
+ * Strips the renderer-injected `<style data-ve-*>` blocks.
+ *
+ * This check covers block markup only. The layout baseline / global-styles
+ * CSS is a known, documented divergence between Blade (which emits it from
+ * `ThemeJsonTokensCompiler::compileLayoutRules()`, gated on theme.json
+ * layout sizes) and the JS renderers (which ship `LAYOUT_BASELINE_CSS`), so
+ * comparing it here would only encode that difference twice.
+ */
+export function stripRendererStyleTags(html: string): string {
+    return html.replace(/<style\s+data-ve-[^>]*>[\s\S]*?<\/style>/g, '');
+}
+
+/**
+ * Class-token regexes declared as known renderer divergences.
+ */
+let dropClassPatterns: RegExp[] = [];
+
+/**
+ * Serializes rendered HTML into the canonical comparison form.
+ *
+ * `dropClassPatternSources` carries regex sources for class tokens that
+ * are declared, documented divergences (see the `knownDivergences` block
+ * in fixtures.json). Matching tokens are dropped from every class
+ * attribute before comparison.
+ */
+export function canonicalizeHtml(
+    html: string,
+    dropClassPatternSources: string[] = []
+): string {
+    dropClassPatterns = dropClassPatternSources.map((source) => new RegExp(source));
+
+    const root = document.createElement('div');
+
+    root.innerHTML = stripRendererStyleTags(html);
+
+    const lines: string[] = [];
+
+    serializeChildren(root, 0, lines);
+
+    return lines.join('\n');
+}
+
+function serializeChildren(parent: Node, depth: number, lines: string[]): void {
+    const kept: Array<{ node: Node; text: string | null }> = [];
+
+    parent.childNodes.forEach((child) => {
+        if (child.nodeType === 3 /* TEXT_NODE */) {
+            const text = collapseWhitespace(child.textContent ?? '');
+
+            if (text.trim() === '') {
+                return;
+            }
+
+            kept.push({ node: child, text });
+
+            return;
+        }
+
+        if (child.nodeType !== 1 /* ELEMENT_NODE */) {
+            // Comments carry no rendered markup; Vue's SSR fragment
+            // markers land here too.
+            return;
+        }
+
+        kept.push({ node: child, text: null });
+    });
+
+    const lastIndex = kept.length - 1;
+
+    kept.forEach((entry, index) => {
+        if (entry.text !== null) {
+            let text = entry.text;
+
+            if (index === 0) {
+                text = text.replace(/^ +/, '');
+            }
+
+            if (index === lastIndex) {
+                text = text.replace(/ +$/, '');
+            }
+
+            if (text === '') {
+                return;
+            }
+
+            lines.push(`${'  '.repeat(depth)}"${escape(text)}"`);
+
+            return;
+        }
+
+        serializeElement(entry.node as Element, depth, lines);
+    });
+}
+
+function serializeElement(element: Element, depth: number, lines: string[]): void {
+    const indent = '  '.repeat(depth);
+    const tag = element.tagName.toLowerCase();
+
+    const attributes = Array.from(element.attributes)
+        .map((attribute) => ({
+            name: attribute.name.toLowerCase(),
+            value: canonicalAttributeValue(
+                attribute.name.toLowerCase(),
+                attribute.value
+            ),
+        }))
+        .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+    const serialized = attributes
+        .map(({ name, value }) => ` ${name}="${escape(value)}"`)
+        .join('');
+
+    if (VOID_ELEMENTS.has(tag)) {
+        lines.push(`${indent}<${tag}${serialized} />`);
+
+        return;
+    }
+
+    lines.push(`${indent}<${tag}${serialized}>`);
+
+    serializeChildren(element, depth + 1, lines);
+
+    lines.push(`${indent}</${tag}>`);
+}
+
+/**
+ * Applies the narrow, per-attribute whitespace normalization.
+ *
+ * `class` gets its whitespace collapsed (token order and spelling are
+ * preserved). `style` gets each declaration trimmed and re-joined with
+ * `; ` so Vue's trailing semicolon and Blade's indentation don't count as
+ * divergence. Every other attribute value is passed through as-is.
+ */
+function canonicalAttributeValue(name: string, value: string): string {
+    if (name === 'class') {
+        return value
+            .trim()
+            .split(/\s+/)
+            .filter(
+                (token) =>
+                    token !== '' &&
+                    !dropClassPatterns.some((pattern) => pattern.test(token))
+            )
+            .join(' ');
+    }
+
+    if (name === 'style') {
+        return value
+            .split(';')
+            .map((declaration) => collapseWhitespace(declaration).trim())
+            .filter((declaration) => declaration !== '')
+            .map((declaration) => {
+                // Whitespace around the property/value colon is
+                // insignificant CSS; React serializes `flex-basis:60%`
+                // where Blade writes `flex-basis: 60%`.
+                const separator = declaration.indexOf(':');
+
+                return separator === -1
+                    ? declaration
+                    : `${declaration.slice(0, separator).trim()}: ${declaration
+                          .slice(separator + 1)
+                          .trim()}`;
+            })
+            .join('; ');
+    }
+
+    return value;
+}
+
+function collapseWhitespace(value: string): string {
+    return value.replace(/\s+/g, ' ');
+}
+
+function escape(value: string): string {
+    return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}

--- a/packages/renderer-markup-parity/fixtures.json
+++ b/packages/renderer-markup-parity/fixtures.json
@@ -1,0 +1,289 @@
+{
+    "$comment": "Shared, language-neutral block trees for the Blade-vs-JS markup parity check (#704). Consumed by both packages/visual-editor-renderer-blade/tests/Feature/RendererMarkupParityTest.php (PHP) and packages/renderer-markup-parity/tests/blade-parity.test.ts (JS). Adding a fixture here automatically exercises it against all three renderers. See README.md for the golden-file workflow.",
+    "knownDivergences": [
+        {
+            "id": "blade-responsive-column-width-scope",
+            "issue": "#712",
+            "reason": "Tracked in #712, introduced by #487. core/column's Blade partial mints a hashed `ve-w-<hash>` scope class and pushes matching `flex-basis`/`flex-grow` `!important` rules into the per-request responsive accumulator, so an explicit column width survives WP core's mobile stacking rule. The React and Vue renderers emit the inline `flex-basis` only and have no equivalent. Dropping the token keeps the rest of the column markup under comparison rather than dropping the width fixture entirely.",
+            "dropClassTokensMatching": "^ve-w-[0-9a-f]{4,}$"
+        }
+    ],
+    "fixtures": [
+        {
+            "name": "paragraph",
+            "tree": [
+                {
+                    "clientId": "p1",
+                    "name": "core/paragraph",
+                    "attributes": { "content": "Hello <strong>world</strong>" },
+                    "innerBlocks": []
+                }
+            ]
+        },
+        {
+            "name": "group-layout-flow",
+            "tree": [
+                {
+                    "clientId": "g-flow",
+                    "name": "core/group",
+                    "attributes": { "layout": { "type": "flow" } },
+                    "innerBlocks": [
+                        {
+                            "clientId": "g-flow-p",
+                            "name": "core/paragraph",
+                            "attributes": { "content": "Flow" },
+                            "innerBlocks": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "group-layout-unset",
+            "tree": [
+                {
+                    "clientId": "g-unset",
+                    "name": "core/group",
+                    "attributes": {},
+                    "innerBlocks": [
+                        {
+                            "clientId": "g-unset-p",
+                            "name": "core/paragraph",
+                            "attributes": { "content": "Default" },
+                            "innerBlocks": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "group-layout-constrained",
+            "tree": [
+                {
+                    "clientId": "g-constrained",
+                    "name": "core/group",
+                    "attributes": { "layout": { "type": "constrained" } },
+                    "innerBlocks": [
+                        {
+                            "clientId": "g-constrained-p",
+                            "name": "core/paragraph",
+                            "attributes": { "content": "Constrained" },
+                            "innerBlocks": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "group-layout-flex",
+            "tree": [
+                {
+                    "clientId": "g-flex",
+                    "name": "core/group",
+                    "attributes": { "layout": { "type": "flex" } },
+                    "innerBlocks": [
+                        {
+                            "clientId": "g-flex-p",
+                            "name": "core/paragraph",
+                            "attributes": { "content": "Flex" },
+                            "innerBlocks": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "group-layout-grid",
+            "tree": [
+                {
+                    "clientId": "g-grid",
+                    "name": "core/group",
+                    "attributes": { "layout": { "type": "grid" } },
+                    "innerBlocks": [
+                        {
+                            "clientId": "g-grid-p",
+                            "name": "core/paragraph",
+                            "attributes": { "content": "Grid" },
+                            "innerBlocks": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "row",
+            "tree": [
+                {
+                    "clientId": "r1",
+                    "name": "core/row",
+                    "attributes": {},
+                    "innerBlocks": [
+                        {
+                            "clientId": "r1-p",
+                            "name": "core/paragraph",
+                            "attributes": { "content": "Row" },
+                            "innerBlocks": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "stack",
+            "tree": [
+                {
+                    "clientId": "s1",
+                    "name": "core/stack",
+                    "attributes": {},
+                    "innerBlocks": [
+                        {
+                            "clientId": "s1-p",
+                            "name": "core/paragraph",
+                            "attributes": { "content": "Stacked" },
+                            "innerBlocks": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "columns",
+            "tree": [
+                {
+                    "clientId": "cols-1",
+                    "name": "core/columns",
+                    "attributes": {},
+                    "innerBlocks": [
+                        {
+                            "clientId": "col-1",
+                            "name": "core/column",
+                            "attributes": { "width": 60 },
+                            "innerBlocks": [
+                                {
+                                    "clientId": "col-1-p",
+                                    "name": "core/paragraph",
+                                    "attributes": { "content": "Left" },
+                                    "innerBlocks": []
+                                }
+                            ]
+                        },
+                        {
+                            "clientId": "col-2",
+                            "name": "core/column",
+                            "attributes": {},
+                            "innerBlocks": [
+                                {
+                                    "clientId": "col-2-p",
+                                    "name": "core/paragraph",
+                                    "attributes": { "content": "Right" },
+                                    "innerBlocks": []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "buttons",
+            "tree": [
+                {
+                    "clientId": "btns-1",
+                    "name": "core/buttons",
+                    "attributes": { "layout": { "justifyContent": "center" } },
+                    "innerBlocks": [
+                        {
+                            "clientId": "b1",
+                            "name": "core/button",
+                            "attributes": {
+                                "text": "Go",
+                                "url": "https://example.com",
+                                "linkTarget": "_blank"
+                            },
+                            "innerBlocks": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "post-content-no-layout",
+            "tree": [
+                {
+                    "clientId": "pc-1",
+                    "name": "core/post-content",
+                    "attributes": { "_resolvedContent": "<p>Body</p>" },
+                    "innerBlocks": []
+                }
+            ]
+        },
+        {
+            "name": "post-content-constrained",
+            "tree": [
+                {
+                    "clientId": "pc-2",
+                    "name": "core/post-content",
+                    "attributes": {
+                        "_resolvedContent": "<p>Body</p>",
+                        "layout": { "type": "constrained" }
+                    },
+                    "innerBlocks": []
+                }
+            ]
+        },
+        {
+            "name": "post-template-list",
+            "tree": [
+                {
+                    "clientId": "pt-list",
+                    "name": "core/post-template",
+                    "attributes": { "layout": "list", "columns": 3 },
+                    "innerBlocks": [
+                        {
+                            "clientId": "pt-list-p",
+                            "name": "core/paragraph",
+                            "attributes": { "content": "Item" },
+                            "innerBlocks": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "post-template-grid",
+            "tree": [
+                {
+                    "clientId": "pt-grid",
+                    "name": "core/post-template",
+                    "attributes": { "layout": "grid", "columns": 3 },
+                    "innerBlocks": [
+                        {
+                            "clientId": "pt-grid-p",
+                            "name": "core/paragraph",
+                            "attributes": { "content": "Item" },
+                            "innerBlocks": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "post-template-masonry",
+            "tree": [
+                {
+                    "clientId": "pt-masonry",
+                    "name": "core/post-template",
+                    "attributes": { "layout": "masonry", "columns": 3 },
+                    "innerBlocks": [
+                        {
+                            "clientId": "pt-masonry-p",
+                            "name": "core/paragraph",
+                            "attributes": { "content": "Item" },
+                            "innerBlocks": []
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/packages/renderer-markup-parity/goldens/buttons.txt
+++ b/packages/renderer-markup-parity/goldens/buttons.txt
@@ -1,0 +1,7 @@
+<div class="wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex is-content-justification-center">
+  <div class="wp-block-button">
+    <a class="wp-block-button__link wp-element-button" href="https://example.com" rel="noopener noreferrer" target="_blank">
+      "Go"
+    </a>
+  </div>
+</div>

--- a/packages/renderer-markup-parity/goldens/columns.txt
+++ b/packages/renderer-markup-parity/goldens/columns.txt
@@ -1,0 +1,12 @@
+<div class="wp-block-columns is-layout-flex wp-block-columns-is-layout-flex is-stacked-on-mobile">
+  <div class="wp-block-column" style="flex-basis: 60%">
+    <p class="wp-block-paragraph">
+      "Left"
+    </p>
+  </div>
+  <div class="wp-block-column">
+    <p class="wp-block-paragraph">
+      "Right"
+    </p>
+  </div>
+</div>

--- a/packages/renderer-markup-parity/goldens/group-layout-constrained.txt
+++ b/packages/renderer-markup-parity/goldens/group-layout-constrained.txt
@@ -1,0 +1,5 @@
+<div class="wp-block-group is-layout-constrained wp-block-group-is-layout-constrained">
+  <p class="wp-block-paragraph">
+    "Constrained"
+  </p>
+</div>

--- a/packages/renderer-markup-parity/goldens/group-layout-flex.txt
+++ b/packages/renderer-markup-parity/goldens/group-layout-flex.txt
@@ -1,0 +1,5 @@
+<div class="wp-block-group is-layout-flex wp-block-group-is-layout-flex">
+  <p class="wp-block-paragraph">
+    "Flex"
+  </p>
+</div>

--- a/packages/renderer-markup-parity/goldens/group-layout-flow.txt
+++ b/packages/renderer-markup-parity/goldens/group-layout-flow.txt
@@ -1,0 +1,5 @@
+<div class="wp-block-group is-layout-flow wp-block-group-is-layout-flow">
+  <p class="wp-block-paragraph">
+    "Flow"
+  </p>
+</div>

--- a/packages/renderer-markup-parity/goldens/group-layout-grid.txt
+++ b/packages/renderer-markup-parity/goldens/group-layout-grid.txt
@@ -1,0 +1,5 @@
+<div class="wp-block-group is-layout-grid wp-block-group-is-layout-grid">
+  <p class="wp-block-paragraph">
+    "Grid"
+  </p>
+</div>

--- a/packages/renderer-markup-parity/goldens/group-layout-unset.txt
+++ b/packages/renderer-markup-parity/goldens/group-layout-unset.txt
@@ -1,0 +1,5 @@
+<div class="wp-block-group is-layout-flow wp-block-group-is-layout-flow">
+  <p class="wp-block-paragraph">
+    "Default"
+  </p>
+</div>

--- a/packages/renderer-markup-parity/goldens/paragraph.txt
+++ b/packages/renderer-markup-parity/goldens/paragraph.txt
@@ -1,0 +1,6 @@
+<p class="wp-block-paragraph">
+  "Hello "
+  <strong>
+    "world"
+  </strong>
+</p>

--- a/packages/renderer-markup-parity/goldens/post-content-constrained.txt
+++ b/packages/renderer-markup-parity/goldens/post-content-constrained.txt
@@ -1,0 +1,5 @@
+<div class="entry-content wp-block-post-content is-layout-constrained wp-block-post-content-is-layout-constrained">
+  <p>
+    "Body"
+  </p>
+</div>

--- a/packages/renderer-markup-parity/goldens/post-content-no-layout.txt
+++ b/packages/renderer-markup-parity/goldens/post-content-no-layout.txt
@@ -1,0 +1,5 @@
+<div class="entry-content wp-block-post-content is-layout-flow wp-block-post-content-is-layout-flow">
+  <p>
+    "Body"
+  </p>
+</div>

--- a/packages/renderer-markup-parity/goldens/post-template-grid.txt
+++ b/packages/renderer-markup-parity/goldens/post-template-grid.txt
@@ -1,0 +1,5 @@
+<ul class="wp-block-post-template is-layout-grid wp-block-post-template-is-layout-grid columns-3">
+  <p class="wp-block-paragraph">
+    "Item"
+  </p>
+</ul>

--- a/packages/renderer-markup-parity/goldens/post-template-list.txt
+++ b/packages/renderer-markup-parity/goldens/post-template-list.txt
@@ -1,0 +1,5 @@
+<ul class="wp-block-post-template is-layout-flow wp-block-post-template-is-layout-flow">
+  <p class="wp-block-paragraph">
+    "Item"
+  </p>
+</ul>

--- a/packages/renderer-markup-parity/goldens/post-template-masonry.txt
+++ b/packages/renderer-markup-parity/goldens/post-template-masonry.txt
@@ -1,0 +1,5 @@
+<ul class="wp-block-post-template is-layout-grid wp-block-post-template-is-layout-grid is-layout-masonry columns-3" data-ap-cols="3">
+  <p class="wp-block-paragraph">
+    "Item"
+  </p>
+</ul>

--- a/packages/renderer-markup-parity/goldens/row.txt
+++ b/packages/renderer-markup-parity/goldens/row.txt
@@ -1,0 +1,5 @@
+<div class="wp-block-group is-layout-flex wp-block-group-is-layout-flex is-horizontal">
+  <p class="wp-block-paragraph">
+    "Row"
+  </p>
+</div>

--- a/packages/renderer-markup-parity/goldens/stack.txt
+++ b/packages/renderer-markup-parity/goldens/stack.txt
@@ -1,0 +1,5 @@
+<div class="wp-block-group is-layout-flex wp-block-group-is-layout-flex is-vertical">
+  <p class="wp-block-paragraph">
+    "Stacked"
+  </p>
+</div>

--- a/packages/renderer-markup-parity/tests/blade-parity.test.ts
+++ b/packages/renderer-markup-parity/tests/blade-parity.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Blade-vs-JS markup parity test (#704).
+ *
+ * Renders every shared fixture in `../fixtures.json` through the React and
+ * Vue renderers and asserts the canonicalized markup matches the golden
+ * file the Blade suite produces
+ * (`packages/visual-editor-renderer-blade/tests/Feature/RendererMarkupParityTest.php`).
+ *
+ * When this fails, one of the three renderers has drifted from the shared
+ * Blade partial contract. Fix the renderer that diverged; only regenerate
+ * the goldens (`composer test:update-markup-goldens`) when the markup
+ * change is intentional and the diff has been reviewed.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createSSRApp, h as vueH } from 'vue';
+import { renderToString as vueRenderToString } from '@vue/server-renderer';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import '../../visual-editor-renderer-vue/src/index';
+import { BlockTree as VueBlockTree } from '../../visual-editor-renderer-vue/src/BlockTree';
+import '../../visual-editor-renderer-react/src/index';
+import { BlockTree as ReactBlockTree } from '../../visual-editor-renderer-react/src/BlockTree';
+import type { Block } from '../../visual-editor-renderer-react/src/types';
+import { canonicalizeHtml } from '../canonicalize';
+
+const parityDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+interface Fixture {
+    name: string;
+    tree: Block[];
+}
+
+interface KnownDivergence {
+    id: string;
+    issue: string;
+    reason: string;
+    dropClassTokensMatching: string;
+}
+
+const MANIFEST: {
+    fixtures: Fixture[];
+    knownDivergences?: KnownDivergence[];
+} = JSON.parse(readFileSync(resolve(parityDir, 'fixtures.json'), 'utf8'));
+
+const FIXTURES = MANIFEST.fixtures;
+
+/**
+ * Declared, documented divergences — see the `knownDivergences` block in
+ * fixtures.json for the reason and tracking issue behind each one.
+ */
+const DROP_CLASS_PATTERNS = (MANIFEST.knownDivergences ?? []).map(
+    (divergence) => divergence.dropClassTokensMatching
+);
+
+function readGolden(name: string): string {
+    // `\r\n` guard: the goldens are compared as exact strings, so a
+    // CRLF checkout must not read as a divergence.
+    return readFileSync(resolve(parityDir, 'goldens', `${name}.txt`), 'utf8')
+        .replace(/\r\n/g, '\n')
+        .replace(/\n+$/, '');
+}
+
+function renderReact(tree: Block[]): string {
+    return canonicalizeHtml(
+        renderToStaticMarkup(createElement(ReactBlockTree, { tree })),
+        DROP_CLASS_PATTERNS
+    );
+}
+
+async function renderVue(tree: Block[]): Promise<string> {
+    const app = createSSRApp({
+        render: () => vueH(VueBlockTree, { tree }),
+    });
+
+    return canonicalizeHtml(await vueRenderToString(app), DROP_CLASS_PATTERNS);
+}
+
+describe('Blade/React/Vue markup parity', () => {
+    it.each(FIXTURES)('React matches the Blade golden for $name', ({ name, tree }) => {
+        expect(renderReact(tree)).toBe(readGolden(name));
+    });
+
+    it.each(FIXTURES)('Vue matches the Blade golden for $name', async ({ name, tree }) => {
+        expect(await renderVue(tree)).toBe(readGolden(name));
+    });
+});

--- a/packages/renderer-markup-parity/tests/blade-parity.test.ts
+++ b/packages/renderer-markup-parity/tests/blade-parity.test.ts
@@ -66,9 +66,26 @@ function readGolden(name: string): string {
         .replace(/\n+$/, '');
 }
 
+/**
+ * Strips the renderer-injected `<style data-ve-*>` blocks.
+ *
+ * This check covers block markup only. The layout baseline / global-styles
+ * CSS is a known, documented divergence between Blade (which emits it from
+ * `ThemeJsonTokensCompiler::compileLayoutRules()`, gated on theme.json
+ * layout sizes) and the JS renderers (which ship `LAYOUT_BASELINE_CSS`), so
+ * comparing it here would only encode that difference twice.
+ *
+ * Mirrors `stripRendererStyleTags()` in the Pest suite.
+ */
+function stripRendererStyleTags(html: string): string {
+    return html.replace(/<style\s+data-ve-[^>]*>[\s\S]*?<\/style>/g, '');
+}
+
 function renderReact(tree: Block[]): string {
     return canonicalizeHtml(
-        renderToStaticMarkup(createElement(ReactBlockTree, { tree })),
+        stripRendererStyleTags(
+            renderToStaticMarkup(createElement(ReactBlockTree, { tree }))
+        ),
         DROP_CLASS_PATTERNS
     );
 }
@@ -78,7 +95,10 @@ async function renderVue(tree: Block[]): Promise<string> {
         render: () => vueH(VueBlockTree, { tree }),
     });
 
-    return canonicalizeHtml(await vueRenderToString(app), DROP_CLASS_PATTERNS);
+    return canonicalizeHtml(
+        stripRendererStyleTags(await vueRenderToString(app)),
+        DROP_CLASS_PATTERNS
+    );
 }
 
 describe('Blade/React/Vue markup parity', () => {

--- a/packages/visual-editor-renderer-blade/tests/Feature/RendererMarkupParityTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/RendererMarkupParityTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Issue #704 — Blade-vs-JS markup parity.
+ *
+ * Renders every shared fixture in
+ * `packages/renderer-markup-parity/fixtures.json` through `<x-ve-blocks>`,
+ * canonicalizes the markup, and compares it against the checked-in golden
+ * file. The vitest side
+ * (`packages/renderer-markup-parity/tests/blade-parity.test.ts`) asserts
+ * the React and Vue renderers produce the same golden, so a divergence in
+ * any of the three renderers fails one of the two suites.
+ *
+ * Regenerate the goldens deliberately, after reviewing the diff:
+ *
+ *     composer test:update-markup-goldens
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ */
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditorRendererBlade\Tests\Support\CanonicalMarkup;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\View;
+
+/**
+ * Render the partials the package ships, never a published copy.
+ *
+ * `vendor:publish --force` (exercised by BlocksComponentTest) drops a
+ * snapshot of the block views into testbench's
+ * `resources/views/vendor/visual-editor-renderer-blade`, and
+ * `loadViewsFrom()` gives that copy priority. A stale snapshot would let
+ * the goldens lock in markup the package no longer emits, so prepend the
+ * source directory for this suite.
+ */
+beforeEach( function () {
+	View::getFinder()->prependNamespace(
+		'visual-editor-renderer-blade',
+		dirname( __DIR__, 2 ) . '/resources/views'
+	);
+
+	View::getFinder()->flush();
+} );
+
+/**
+ * Absolute path to the shared parity directory.
+ */
+function markupParityPath( string $relative = '' ): string
+{
+	$root = dirname( __DIR__, 3 ) . '/renderer-markup-parity';
+
+	return '' === $relative ? $root : $root . '/' . $relative;
+}
+
+/**
+ * Decodes the shared parity manifest.
+ *
+ * @return array<string, mixed>
+ */
+function markupParityManifest(): array
+{
+	return json_decode(
+		(string) file_get_contents( markupParityPath( 'fixtures.json' ) ),
+		true,
+		512,
+		JSON_THROW_ON_ERROR
+	);
+}
+
+/**
+ * Class-token regexes for the declared, documented renderer divergences.
+ *
+ * @return array<int, string>
+ */
+function markupParityDropClassPatterns(): array
+{
+	return array_map(
+		static fn ( array $divergence ): string => $divergence['dropClassTokensMatching'],
+		markupParityManifest()['knownDivergences'] ?? []
+	);
+}
+
+/**
+ * Loads the shared, language-neutral fixture set.
+ *
+ * @return array<string, array{0: string, 1: array<int, mixed>}>
+ */
+function markupParityFixtures(): array
+{
+	$json = markupParityManifest();
+
+	$dataset = [];
+
+	foreach ( $json['fixtures'] as $fixture ) {
+		$dataset[ $fixture['name'] ] = [ $fixture['name'], $fixture['tree'] ];
+	}
+
+	return $dataset;
+}
+
+/**
+ * Strips the renderer-injected `<style data-ve-*>` blocks.
+ *
+ * This check covers block markup only. The layout baseline / global-styles
+ * CSS is a known, documented divergence between Blade (which emits it from
+ * `ThemeJsonTokensCompiler::compileLayoutRules()`, gated on theme.json
+ * layout sizes) and the JS renderers (which ship `LAYOUT_BASELINE_CSS`), so
+ * comparing it here would only encode that difference twice.
+ */
+function stripRendererStyleTags( string $html ): string
+{
+	return (string) preg_replace( '#<style\s+data-ve-[^>]*>.*?</style>#s', '', $html );
+}
+
+it( 'matches the golden markup shared with the React and Vue renderers', function ( string $name, array $tree ) {
+	$rendered = Blade::render( '<x-ve-blocks :tree="$tree" />', [ 'tree' => $tree ] );
+
+	$canonical = CanonicalMarkup::fromHtml(
+		stripRendererStyleTags( $rendered ),
+		markupParityDropClassPatterns()
+	);
+
+	$goldenPath = markupParityPath( 'goldens/' . $name . '.txt' );
+
+	if ( '1' === getenv( 'UPDATE_MARKUP_GOLDENS' ) ) {
+		if ( ! is_dir( dirname( $goldenPath ) ) ) {
+			mkdir( dirname( $goldenPath ), 0o755, true );
+		}
+
+		file_put_contents( $goldenPath, $canonical . "\n" );
+	}
+
+	expect( file_exists( $goldenPath ) )->toBeTrue(
+		'Missing golden for fixture "' . $name . '". Run: composer test:update-markup-goldens'
+	);
+
+	// `\r\n` guard: the goldens are compared as exact strings, so a CRLF
+	// checkout must not read as a divergence.
+	$golden = str_replace( "\r\n", "\n", (string) file_get_contents( $goldenPath ) );
+
+	expect( $canonical )->toBe( rtrim( $golden, "\n" ) );
+} )->with( markupParityFixtures() );
+
+it( 'has a golden for every fixture and no orphaned goldens', function () {
+	$expected = array_keys( markupParityFixtures() );
+
+	$actual = array_map(
+		static fn ( string $path ): string => basename( $path, '.txt' ),
+		glob( markupParityPath( 'goldens/*.txt' ) ) ?: []
+	);
+
+	sort( $expected );
+	sort( $actual );
+
+	expect( $actual )->toBe( $expected );
+} );

--- a/packages/visual-editor-renderer-blade/tests/Support/CanonicalMarkup.php
+++ b/packages/visual-editor-renderer-blade/tests/Support/CanonicalMarkup.php
@@ -1,0 +1,326 @@
+<?php
+
+/**
+ * Canonical markup serializer for the Blade-vs-JS parity check (#704).
+ *
+ * Parses rendered HTML and re-emits it as an indented, deterministic
+ * tree so the Blade renderer's output can be compared against the
+ * React / Vue renderers' output without tripping over incidental
+ * formatting differences.
+ *
+ * Normalization is deliberately narrow — see README.md in
+ * packages/renderer-markup-parity for the exact contract. In short:
+ * whitespace and attribute order are normalized; element names, class
+ * tokens and attribute values are not.
+ *
+ * The TypeScript twin of this class lives at
+ * packages/renderer-markup-parity/canonicalize.ts. Any change here must
+ * be mirrored there or the two suites stop agreeing.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage VisualEditorRendererBlade
+ *
+ * @since      1.6.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\VisualEditorRendererBlade\Tests\Support;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMText;
+
+final class CanonicalMarkup
+{
+	/**
+	 * HTML elements that never have children and are emitted self-closed.
+	 *
+	 * @var array<int, string>
+	 */
+	private const VOID_ELEMENTS = [
+		'area',
+		'base',
+		'br',
+		'col',
+		'embed',
+		'hr',
+		'img',
+		'input',
+		'link',
+		'meta',
+		'param',
+		'source',
+		'track',
+		'wbr',
+	];
+
+	/**
+	 * Class-token regexes declared as known renderer divergences.
+	 *
+	 * @var array<int, string>
+	 */
+	private static array $dropClassPatterns = [];
+
+	/**
+	 * Serializes rendered HTML into the canonical comparison form.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  string             $html                Rendered HTML fragment.
+	 * @param  array<int, string> $dropClassPatterns   Unanchored-delimiter regex
+	 *                                                 sources for class tokens that
+	 *                                                 are declared, documented
+	 *                                                 divergences (see the
+	 *                                                 `knownDivergences` block in
+	 *                                                 fixtures.json). Matching tokens
+	 *                                                 are dropped from every class
+	 *                                                 attribute before comparison.
+	 *
+	 * @return string Canonical, newline-delimited markup tree.
+	 */
+	public static function fromHtml( string $html, array $dropClassPatterns = [] ): string
+	{
+		self::$dropClassPatterns = $dropClassPatterns;
+
+		$document = new DOMDocument();
+
+		$previous = libxml_use_internal_errors( true );
+
+		$document->loadHTML(
+			'<!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><div id="ve-parity-root">'
+			. $html
+			. '</div></body></html>'
+		);
+
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+
+		$root = $document->getElementById( 've-parity-root' );
+
+		if ( ! $root instanceof DOMElement ) {
+			return '';
+		}
+
+		$lines = [];
+
+		self::serializeChildren( $root, 0, $lines );
+
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Serializes an element's children, dropping insignificant whitespace.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  DOMNode              $parent  Node whose children are serialized.
+	 * @param  int                  $depth   Current indentation depth.
+	 * @param  array<int, string>   $lines   Accumulated output lines.
+	 */
+	private static function serializeChildren( DOMNode $parent, int $depth, array &$lines ): void
+	{
+		/** @var array<int, array{node: DOMNode, text: string|null}> $kept */
+		$kept = [];
+
+		foreach ( $parent->childNodes as $child ) {
+			if ( $child instanceof DOMText ) {
+				$text = self::collapseWhitespace( $child->textContent );
+
+				if ( '' === trim( $text ) ) {
+					continue;
+				}
+
+				$kept[] = [ 'node' => $child, 'text' => $text ];
+
+				continue;
+			}
+
+			if ( ! $child instanceof DOMElement ) {
+				// Comments and processing instructions carry no rendered
+				// markup; Vue's SSR fragment markers land here too.
+				continue;
+			}
+
+			$kept[] = [ 'node' => $child, 'text' => null ];
+		}
+
+		$lastIndex = count( $kept ) - 1;
+
+		foreach ( $kept as $index => $entry ) {
+			if ( null !== $entry['text'] ) {
+				$text = $entry['text'];
+
+				if ( 0 === $index ) {
+					$text = ltrim( $text );
+				}
+
+				if ( $index === $lastIndex ) {
+					$text = rtrim( $text );
+				}
+
+				if ( '' === $text ) {
+					continue;
+				}
+
+				$lines[] = str_repeat( '  ', $depth ) . '"' . self::escape( $text ) . '"';
+
+				continue;
+			}
+
+			/** @var DOMElement $element */
+			$element = $entry['node'];
+
+			self::serializeElement( $element, $depth, $lines );
+		}
+	}
+
+	/**
+	 * Serializes a single element and, recursively, its children.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  DOMElement          $element  Element to serialize.
+	 * @param  int                 $depth    Current indentation depth.
+	 * @param  array<int, string>  $lines    Accumulated output lines.
+	 */
+	private static function serializeElement( DOMElement $element, int $depth, array &$lines ): void
+	{
+		$indent = str_repeat( '  ', $depth );
+		$tag    = strtolower( $element->tagName );
+
+		$attributes = [];
+
+		foreach ( $element->attributes as $attribute ) {
+			$name = strtolower( $attribute->nodeName );
+
+			$attributes[ $name ] = self::canonicalAttributeValue( $name, (string) $attribute->nodeValue );
+		}
+
+		ksort( $attributes );
+
+		$serialized = '';
+
+		foreach ( $attributes as $name => $value ) {
+			$serialized .= ' ' . $name . '="' . self::escape( $value ) . '"';
+		}
+
+		if ( in_array( $tag, self::VOID_ELEMENTS, true ) ) {
+			$lines[] = $indent . '<' . $tag . $serialized . ' />';
+
+			return;
+		}
+
+		$lines[] = $indent . '<' . $tag . $serialized . '>';
+
+		self::serializeChildren( $element, $depth + 1, $lines );
+
+		$lines[] = $indent . '</' . $tag . '>';
+	}
+
+	/**
+	 * Applies the narrow, per-attribute whitespace normalization.
+	 *
+	 * `class` gets its whitespace collapsed (token order and spelling are
+	 * preserved). `style` gets each declaration trimmed and re-joined with
+	 * `; ` so Vue's trailing semicolon and Blade's indentation don't count
+	 * as divergence. Every other attribute value is passed through as-is.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  string  $name   Lowercased attribute name.
+	 * @param  string  $value  Raw attribute value.
+	 *
+	 * @return string Canonical attribute value.
+	 */
+	private static function canonicalAttributeValue( string $name, string $value ): string
+	{
+		if ( 'class' === $name ) {
+			$tokens = [];
+
+			foreach ( preg_split( '/\s+/', trim( $value ) ) ?: [] as $token ) {
+				if ( '' === $token || self::isDeclaredDivergentClass( $token ) ) {
+					continue;
+				}
+
+				$tokens[] = $token;
+			}
+
+			return implode( ' ', $tokens );
+		}
+
+		if ( 'style' === $name ) {
+			$declarations = [];
+
+			foreach ( explode( ';', $value ) as $declaration ) {
+				$declaration = trim( self::collapseWhitespace( $declaration ) );
+
+				if ( '' === $declaration ) {
+					continue;
+				}
+
+				// Whitespace around the property/value colon is
+				// insignificant CSS; React serializes `flex-basis:60%`
+				// where Blade writes `flex-basis: 60%`.
+				$parts = explode( ':', $declaration, 2 );
+
+				$declarations[] = 2 === count( $parts )
+					? trim( $parts[0] ) . ': ' . trim( $parts[1] )
+					: $declaration;
+			}
+
+			return implode( '; ', $declarations );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Whether a class token is a declared, documented divergence.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  string  $token  Single class token.
+	 *
+	 * @return bool True when the token should be dropped before comparison.
+	 */
+	private static function isDeclaredDivergentClass( string $token ): bool
+	{
+		foreach ( self::$dropClassPatterns as $pattern ) {
+			if ( 1 === preg_match( '#' . $pattern . '#', $token ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Collapses every run of whitespace down to a single space.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  string  $value  Value to collapse.
+	 *
+	 * @return string Collapsed value.
+	 */
+	private static function collapseWhitespace( string $value ): string
+	{
+		return (string) preg_replace( '/\s+/u', ' ', $value );
+	}
+
+	/**
+	 * Escapes backslashes and double quotes for the quoted output form.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param  string  $value  Value to escape.
+	 *
+	 * @return string Escaped value.
+	 */
+	private static function escape( string $value ): string
+	{
+		return str_replace( [ '\\', '"' ], [ '\\\\', '\"' ], $value );
+	}
+}


### PR DESCRIPTION
## Description

Nothing guarded against the Blade, React and Vue renderers drifting on **markup**. `scripts/verify-renderer-parity.mjs` compares registered block *names* only, and `packages/visual-editor-renderer-vue/tests/parity.test.ts` compares React against Vue with Blade left out of both. That is exactly why the Blade-only #700 fix could land green while silently making Blade disagree with the JS renderers, undetected until #702 was filed.

This adds a shared fixture set rendered through all three renderers, so that class of bug fails CI at the point it is introduced.

**Closes:** #704

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #704

## Motivation and Context

The three renderers are meant to be interchangeable — `parity.test.ts` describes them as sharing "the Blade partial contract" — but that invariant had no enforcement across the PHP/JS boundary. Four distinct class-emission bugs sat in `main` in the meantime, one of which (`group` ignoring `layout.type: grid`) predated #700 entirely.

## Changes Made

- **`packages/renderer-markup-parity/fixtures.json`** — one language-neutral source of truth: the block trees plus a `knownDivergences` manifest. A fixture added here is automatically exercised against all three renderers.
- **Blade suite writes the goldens.** `RendererMarkupParityTest.php` renders each fixture through `<x-ve-blocks>`, canonicalizes, and compares against `goldens/<name>.txt`.
- **JS suite reads them.** `tests/blade-parity.test.ts` renders each fixture through the React and Vue SSR entry points and asserts equality with the golden.
- **Two mirrored canonicalizers** (`canonicalize.ts` / `CanonicalMarkup.php`) implementing one documented algorithm.
- `composer test:update-markup-goldens` regenerates the goldens deliberately; `README.md` documents the contract and the workflow.

Fixture coverage: `group` (flow / constrained / flex / grid / unset), `row`, `stack`, `columns`, `buttons`, `post-content` with and without a stored layout, `post-template` (list / grid / masonry), plus a paragraph baseline.

**Normalization is narrow and explicit.** Normalized: whitespace, attribute order, `class` whitespace, CSS declaration separators (Vue emits a trailing `;`, React writes `flex-basis:60%` where Blade writes `flex-basis: 60%`), comments. Not normalized: element names, class tokens, attribute names, attribute values.

**Scope is markup, not CSS.** Renderer-injected `<style data-ve-*>` blocks are stripped on both sides — the JS `LAYOUT_BASELINE_CSS` constrained-group rules vs. Blade's `ThemeJsonTokensCompiler::compileLayoutRules()` gating is a known intentional divergence, and comparing it here would only encode it a second time.

**One subtle fix worth flagging in review:** the parity test prepends the package's own view directory in `beforeEach`. `vendor:publish --force` (exercised by `BlocksComponentTest`) drops a snapshot of the block views into testbench's `resources/views/vendor/`, and `loadViewsFrom()` gives that copy priority. Without the prepend, a stale local snapshot lets the goldens lock in markup the package no longer emits — my first defect-reintroduction experiment passed falsely because of it.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4.3
- Project Version: release/1.6

**Tests Performed:**

1. Full Pest suite — 1757 passed, 1 skipped.
2. Full vitest suite — 336 files, 3172 passed.
3. **Defect re-introduction (issue AC 6), verified by actually reverting locally:**
   - `git show cac35901 -- packages/visual-editor-renderer-{react,vue}/src | git apply -R -` (the four #702 defects) → **28 of 30** vitest cases fail: every group layout variant, row, stack, columns, buttons, both post-content cases, all three post-template cases, on both React and Vue.
   - `git show f1459421 -- packages/visual-editor-renderer-blade/resources/views | git apply -R -` (the #700 Blade defect) → **14 of 16** Pest cases fail.
   - Reverting the reverts returns both suites to green.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — test infrastructure only. No runtime code, markup or styling changes ship in this PR.

## Tests Added

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 16 Pest cases (15 fixtures + a golden/fixture set-equality guard that catches orphaned or missing goldens after a rename) and 30 vitest cases (each fixture × React and Vue). Both run in CI on every PR via the existing `test-php` and `test-js` jobs — no new workflow needed.

## Documentation

- [x] Inline code documentation added
- [x] README updated

**Documentation details:** `packages/renderer-markup-parity/README.md` documents the golden workflow, the exact canonicalization contract, why CSS is out of scope, and both known divergences. CHANGELOG entry added under Unreleased → Added.

## Divergences surfaced

Building the check found two genuine, pre-existing renderer divergences. Neither is papered over with loose matching:

- **#712 — `core/column` responsive width.** Blade mints a hashed `ve-w-<hash>` scope class plus `!important` breakpoint rules (#487) so an explicit width survives WP core's mobile stacking rule; React and Vue emit the inline `flex-basis` only, so column widths collapse to 100% below 782px on JS-rendered pages. Declared in the manifest with its reason and tracking issue, dropping only that one class token so the rest of the column markup — including the inline style — stays under comparison.
- **#711 — `core/group` flex-panel layout flip.** `group.blade.php` flips to `is-layout-flex` when the #595 panel is active at the base breakpoint; the JS renderers have no equivalent. Deliberately left uncovered by any fixture, per the issue's guidance, and filed for a renderer fix.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed (N/A — see above)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated
