### PR TITLE
fix: fire the namespaced comments form action filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **The `post-comments-form` block fires `ap.cmsFramework.comments.form.action`**
+  (cms-framework#245) — this block is the only fire site in the ecosystem for
+  the comment form's action filter, but it emitted the un-prefixed legacy name
+  `comments.form.action`. The CMS Framework's 2.5.0 hook-rename wave listed that
+  filter as moved under `ap.cmsFramework.*` and its CHANGELOG said so, but the
+  alias never shipped there, so the documented new name resolved to nothing and
+  hosts had to stay on the old one. cms-framework 2.8.0 lands the missing alias
+  and this release moves the fire site onto the canonical name to match. The
+  filter keeps a cms-framework namespace rather than gaining a visual-editor one
+  because comments are that package's domain and its `POST /api/v1/comments`
+  endpoint is this filter's default value — the same emitter-is-not-owner split
+  as `ap.rbac.roleRegistered`. **No action is required:** `comments.form.action`
+  is registered as a deprecation alias here as well as in cms-framework, so a
+  subscriber on either name still fires, in either direction. The alias is
+  declared on this side deliberately — cms-framework is not a dependency of this
+  package, so a host rendering this block without it would otherwise have no
+  alias registered at all. Hosts should migrate to
+  `ap.cmsFramework.comments.form.action`; the old name logs a deprecation notice
+  the first time it resolves per request.
+- **Hosts that published this package's block views must re-publish to pick the
+  new hook name up** — `resources/views/vendor/visual-editor-renderer-blade/`
+  shadows the package's own partials, so a published copy of
+  `blocks/artisanpack/post-comments-form.blade.php` keeps firing the old name
+  until it is refreshed with
+  `php artisan vendor:publish --tag=visual-editor-blade-views --force`.
+  Behavior is unchanged either way thanks to the alias; this only affects which
+  name is emitted and therefore whether a deprecation notice is logged.
+
+### Fixed
+
+- **The renderer-blade suite registers `HooksServiceProvider`, so hook aliases
+  actually resolve under test** — its `TestCase` listed only the visual-editor
+  and renderer providers. `HookDeprecations` is bound as a singleton by the
+  hooks provider, so without it every `app( HookDeprecations::class )` call
+  resolved a *fresh* instance: the aliases registered in
+  `VisualEditorServiceProvider::boot()` were written to an object nothing else
+  ever read, and no legacy hook name resolved. The failure was silent rather
+  than loud — the canonical name still fired normally, so only a test
+  specifically asserting an *old* name would catch it. The root suite's
+  `TestCase` has always registered the provider; the two are now consistent.
+
 ## [1.6.0] - 2026-08-07
 
 ### Added

--- a/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-comments-form.blade.php
+++ b/packages/visual-editor-renderer-blade/resources/views/blocks/artisanpack/post-comments-form.blade.php
@@ -7,13 +7,17 @@
 	// which is great for SPAs but not for a plain HTML form submit —
 	// the browser navigates to the JSON. Host apps that want a
 	// classic form-post UX should override this via the
-	// `comments.form.action` filter (artisanpack-ui/hooks) and point
-	// it at a controller that creates the comment and redirects back.
+	// `ap.cmsFramework.comments.form.action` filter (artisanpack-ui/hooks)
+	// and point it at a controller that creates the comment and redirects
+	// back. The filter carries the cms-framework namespace rather than a
+	// visual-editor one because comments are that package's domain and its
+	// endpoint is this default's value; the pre-2.8 name
+	// `comments.form.action` is aliased on both sides and still resolves.
 	$defaultAction = isset( $attributes['_resolvedFormAction'] ) && is_string( $attributes['_resolvedFormAction'] )
 		? $attributes['_resolvedFormAction']
 		: '/api/v1/comments';
 	if ( function_exists( 'applyFilters' ) ) {
-		$defaultAction = ( string ) applyFilters( 'comments.form.action', $defaultAction );
+		$defaultAction = ( string ) applyFilters( 'ap.cmsFramework.comments.form.action', $defaultAction );
 	}
 	$formAction = UrlSanitizer::safe( $defaultAction );
 @endphp
@@ -22,10 +26,10 @@
 
 	Renders a minimal, semantically-correct comment form. The default
 	`action` posts to cms-framework's `/api/v1/comments` endpoint; the
-	`comments.form.action` filter lets host apps redirect submissions
-	to their own controller so they can validate, persist, and redirect
-	back to the post with a flash message — the standard browser-form
-	UX the API endpoint can't provide on its own.
+	`ap.cmsFramework.comments.form.action` filter lets host apps redirect
+	submissions to their own controller so they can validate, persist, and
+	redirect back to the post with a flash message — the standard
+	browser-form UX the API endpoint can't provide on its own.
 --}}
 <div{!! BlockSupports::wrapperAttrs( $attributes, [ 'wp-block-post-comments-form', 'comment-respond' ] ) !!}>
 	<h3 class="comment-reply-title">{{ __( 'Leave a Comment' ) }}</h3>

--- a/packages/visual-editor-renderer-blade/tests/Feature/PostCommentsFormActionFilterTest.php
+++ b/packages/visual-editor-renderer-blade/tests/Feature/PostCommentsFormActionFilterTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\VisualEditorRendererBlade\BlockRenderer;
+
+/**
+ * cms-framework#245 — the `post-comments-form` block is the only fire site
+ * for the comment form's action filter, but the filter is namespaced under
+ * `ap.cmsFramework.*` because comments are that package's domain. The name
+ * was un-prefixed before 2.8.0 and the fire site had never been covered, so
+ * nothing would have caught the rename silently dropping a host's override.
+ */
+
+afterEach( function (): void {
+	removeAllFilters( 'comments.form.action' );
+	removeAllFilters( 'ap.cmsFramework.comments.form.action' );
+} );
+
+it( 'posts to the cms-framework comments endpoint by default', function (): void {
+	$html = app( BlockRenderer::class )->renderBlock( [
+		'name'       => 'artisanpack/post-comments-form',
+		'attributes' => [],
+	] );
+
+	expect( $html )->toContain( 'action="/api/v1/comments"' );
+} );
+
+it( 'lets a host redirect the form action through the namespaced filter', function (): void {
+	addFilter( 'ap.cmsFramework.comments.form.action', static fn (): string => '/comments' );
+
+	$html = app( BlockRenderer::class )->renderBlock( [
+		'name'       => 'artisanpack/post-comments-form',
+		'attributes' => [],
+	] );
+
+	expect( $html )->toContain( 'action="/comments"' );
+	expect( $html )->not->toContain( 'action="/api/v1/comments"' );
+} );
+
+it( 'still honors a host subscribed under the pre-2.8 un-prefixed name', function (): void {
+	addFilter( 'comments.form.action', static fn (): string => '/comments' );
+
+	$html = app( BlockRenderer::class )->renderBlock( [
+		'name'       => 'artisanpack/post-comments-form',
+		'attributes' => [],
+	] );
+
+	expect( $html )->toContain( 'action="/comments"' );
+} );

--- a/packages/visual-editor-renderer-blade/tests/TestCase.php
+++ b/packages/visual-editor-renderer-blade/tests/TestCase.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\VisualEditorRendererBlade\Tests;
 
+use ArtisanPackUI\Hooks\Providers\HooksServiceProvider;
 use ArtisanPackUI\VisualEditor\VisualEditorServiceProvider;
 use ArtisanPackUI\VisualEditorRendererBlade\VisualEditorRendererBladeServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -18,6 +19,16 @@ abstract class TestCase extends BaseTestCase
 	protected function getPackageProviders( $app ): array
 	{
 		return [
+			// Registered first, and ahead of the visual-editor provider,
+			// because it binds `HookDeprecations` as a singleton. Without
+			// it every `app( HookDeprecations::class )` resolves a fresh
+			// instance, so the aliases `VisualEditorServiceProvider::boot()`
+			// registers land on a throwaway object and no legacy hook name
+			// resolves — silently, since the un-aliased name still fires.
+			// The root suite's TestCase has always registered it; this one
+			// had not, which is why block partials that fire a renamed hook
+			// went uncovered here (cms-framework#245).
+			HooksServiceProvider::class,
 			VisualEditorServiceProvider::class,
 			VisualEditorRendererBladeServiceProvider::class,
 		];

--- a/src/Support/HookAliases.php
+++ b/src/Support/HookAliases.php
@@ -40,6 +40,14 @@ class HookAliases
 	 * visual-editor before the icons package publishes its own alias
 	 * registration.
 	 *
+	 * `comments.form.action` is declared for the same defensive reason. Its
+	 * canonical alias belongs to `artisanpack-ui/cms-framework` (2.8.0+,
+	 * cms-framework#245), which owns the `ap.cmsFramework.*` namespace even
+	 * though the `post-comments-form` block here is the only fire site. That
+	 * package is not a dependency of this one, so a host rendering this block
+	 * without it would otherwise have no alias registered at all and every
+	 * pre-2.8 subscriber on the un-prefixed name would silently stop firing.
+	 *
 	 * @var array<string, string>
 	 */
 	private const RENAMES = [
@@ -58,6 +66,7 @@ class HookAliases
 		'ap.visual-editor.loginout.login-form'          => 'ap.visualEditor.loginout.loginForm',
 		'visual_editor.pre_publish_checks'              => 'ap.visualEditor.prePublishChecks',
 		'ap.icons.register-icon-sets'                   => 'ap.icons.registerIconSets',
+		'comments.form.action'                         => 'ap.cmsFramework.comments.form.action',
 	];
 
 	/**

--- a/tests/Feature/VisualEditor/HookAliasesTest.php
+++ b/tests/Feature/VisualEditor/HookAliasesTest.php
@@ -31,6 +31,8 @@ afterEach( function (): void {
 	removeAllFilters( 'ap.visualEditor.renderedBlock' );
 	removeAllFilters( 'ap.visual-editor.loginout.envelope' );
 	removeAllFilters( 'ap.visualEditor.loginout.envelope' );
+	removeAllFilters( 'comments.form.action' );
+	removeAllFilters( 'ap.cmsFramework.comments.form.action' );
 } );
 
 it( 'routes old-name resources subscribers when the new name is applied', function (): void {
@@ -155,4 +157,32 @@ it( 'routes new-name loginout envelope subscribers when the old name is applied'
 	$result = applyFilters( 'ap.visual-editor.loginout.envelope', [] );
 
 	expect( $result )->toHaveKey( 'touched' );
+} );
+
+/*
+ * `comments.form.action` — cms-framework owns the `ap.cmsFramework.*`
+ * namespace (cms-framework#245) but the `post-comments-form` block here is
+ * the only fire site, and cms-framework is not a dependency of this package.
+ * These assert the defensive alias declared in RENAMES so the un-prefixed
+ * name keeps resolving in a visual-editor-only install.
+ */
+
+it( 'routes old-name comments form action subscribers when the new name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'comments.form.action', static fn (): string => '/comments' );
+
+	$result = applyFilters( 'ap.cmsFramework.comments.form.action', '/api/v1/comments' );
+
+	expect( $result )->toBe( '/comments' );
+} );
+
+it( 'routes new-name comments form action subscribers when the old name is applied', function (): void {
+	HookAliases::registerAll();
+
+	addFilter( 'ap.cmsFramework.comments.form.action', static fn (): string => '/comments' );
+
+	$result = applyFilters( 'comments.form.action', '/api/v1/comments' );
+
+	expect( $result )->toBe( '/comments' );
 } );


### PR DESCRIPTION
## Description

The `post-comments-form` block is the ecosystem's only fire site for the comment form's action filter, but it emitted the un-prefixed legacy name `comments.form.action`. cms-framework's 2.5.0 rename wave documented that filter as moved under `ap.cmsFramework.*` without ever shipping the alias; with that alias now landing in cms-framework 2.8.0, this moves the fire site onto the canonical name to match.

**Closes:** n/a — the tracking issue is [ArtisanPack-UI/cms-framework#245](https://github.com/ArtisanPack-UI/cms-framework/issues/245).

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** ArtisanPack-UI/cms-framework#245 · companion PR ArtisanPack-UI/cms-framework#293

## Motivation and Context

cms-framework#245 asked which package owns this filter's namespace given the split between fire site (here) and domain (there). The decision was that **cms-framework keeps ownership** — comments are its domain and its `POST /api/v1/comments` endpoint is this filter's default value, the same emitter-is-not-owner split as `ap.rbac.roleRegistered`, which cms-framework fires under the RBAC namespace.

That choice carries one risk this PR closes: **cms-framework is not a dependency of this package** (`require`: core + hooks only). An alias registered only over there would never load in a visual-editor-only install, so every pre-2.8 subscriber on the un-prefixed name would silently stop firing the moment this fire site moved. Declaring the identical alias here removes that failure mode — the same defensive cross-package declaration `HookAliases` already makes for `ap.icons.register-icon-sets`. `deprecateHook()` is idempotent per (old, new) pair, so the two declarations coexist safely and the two PRs are independently releasable in either order.

## Changes Made

- `post-comments-form.blade.php` fires `ap.cmsFramework.comments.form.action`; the block's two prose comments describing the filter were updated to match.
- `HookAliases::RENAMES` gains `comments.form.action` → `ap.cmsFramework.comments.form.action`, with a docblock recording why a foreign-namespace alias is declared here.
- **Fixes a test-harness gap the new coverage exposed:** `packages/visual-editor-renderer-blade/tests/TestCase.php` never registered `HooksServiceProvider`, which binds `HookDeprecations` as a singleton. Without it every `app( HookDeprecations::class )` resolved a *fresh* instance, so the aliases registered in `VisualEditorServiceProvider::boot()` were written to an object nothing else ever read and **no legacy hook name resolved anywhere in that suite**. It failed silently rather than loudly, because canonical names still fire normally — only a test asserting an *old* name would ever notice. The root suite's `TestCase` has always registered it; the two are now consistent.
- CHANGELOG: an Unreleased section covering the rename, the harness fix, and the published-views note below.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 27.0.0)
- Browser (if applicable): n/a
- PHP Version: 8.4.23
- Project Version: 1.6.0 (`release/1.x`)

**Tests Performed:**
1. `./vendor/bin/pest` — full suite, **1737 passed / 38 skipped** (4534 assertions), including the RendererBlade testsuite.
2. `./vendor/bin/pest packages/visual-editor-renderer-blade/tests/Feature/PostCommentsFormActionFilterTest.php` — 3 passed.
3. Verified the new cases run in the *default* suite, not only when named explicitly.
4. Manually rendered the block in the dev app: default action, new-name override, and old-name override all behave.

> **Worth knowing for reviewers, and captured in the CHANGELOG.** The new render test initially failed in a way that turned out not to be the code: a stale published copy of this block view under `resources/views/vendor/visual-editor-renderer-blade/` shadows the package's own partial. That is not merely a local artifact — **any host that has run `vendor:publish` keeps firing the old name until they re-publish** with `php artisan vendor:publish --tag=visual-editor-blade-views --force`. Behavior is unchanged either way thanks to the alias; it only affects which name is emitted, and therefore whether a deprecation notice is logged.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [x] ARIA labels checked

**Details:** The block's markup is unchanged by this PR — the diff touches the value of the `<form action>` attribute's *source hook name* and two comments, nothing structural. Keyboard traversal of the form (label/input association, submit reachability) and the absence of ARIA regressions were confirmed against the rendered output; no color or screen-reader surface is involved.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** New `PostCommentsFormActionFilterTest.php` covers the fire site end-to-end through `BlockRenderer::renderBlock()` — default endpoint, an override via the namespaced name, and an override via the pre-2.8 un-prefixed name (the downstream compat path). **This fire site previously had no coverage at all**, which is why nothing caught the original rename never landing. Two matching cases were added to `tests/Feature/VisualEditor/HookAliasesTest.php` for both alias directions.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Docblocks on `HookAliases::RENAMES` and the renderer-blade `TestCase`, plus the block's own prose comments. `docs/` mentions this filter nowhere, so there is no drift to correct there.

## Screenshots

n/a — no visual change.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [ ] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

> Linting unchecked because this package ships no linter — neither `php-cs-fixer` nor `pint` is in `vendor/bin`, and `composer.json` defines no `lint`/`fix` script. The changed files follow the surrounding style by hand. Adding the standard `artisanpack-ui/code-style` tooling here is worth a separate issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Introduced the canonical `ap.cmsFramework.comments.form.action` hook for customizing comment form destinations.
  * Existing integrations using `comments.form.action` remain supported through a compatibility alias.
  * Added deprecation guidance for the legacy hook name.
  * Updated comment form template documentation with the new hook name and namespace.
  * Applications with overridden comment form views should republish them to receive the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->